### PR TITLE
Use own cache filename for each network interface

### DIFF
--- a/include/dyndns.h
+++ b/include/dyndns.h
@@ -55,6 +55,7 @@ typedef enum
 #define DYNDNS_DEFAULT_CONFIG_FILE	"/etc/inadyn.conf"
 #define DYNDNS_RUNTIME_DATA_DIR		"/var/run/inadyn"
 #define DYNDNS_DEFAULT_CACHE_FILE	DYNDNS_RUNTIME_DATA_DIR"/inadyn.cache"
+#define DYNDNS_CACHE_FILE		DYNDNS_RUNTIME_DATA_DIR"/%s.cache"
 #define DYNDNS_DEFAULT_PIDFILE		DYNDNS_RUNTIME_DATA_DIR"/inadyn.pid"
 
 #define DYNDNS_MY_USERNAME		"test"
@@ -314,6 +315,7 @@ typedef struct DYN_DNS_CLIENT
 	int          total_iterations;
 	int          num_iterations;
 	char        *interface;
+	char        *cache_file;
 	BOOL         initialized;
 	BOOL         run_in_background;
 	BOOL         debug_to_syslog;

--- a/src/dyndns.c
+++ b/src/dyndns.c
@@ -762,12 +762,12 @@ static RC_TYPE do_update_alias_table(DYN_DNS_CLIENT *p_self)
 	}
 
 	/* Successful change or when cache file does not yet exist! */
-	if (anychange || access(DYNDNS_DEFAULT_CACHE_FILE, F_OK))
+	if (anychange || access(p_self->cache_file, F_OK))
 	{
 		FILE *fp;
 
 		/* Update cache with new IP */
-		fp = fopen(DYNDNS_DEFAULT_CACHE_FILE, "w");
+		fp = fopen(p_self->cache_file, "w");
 		if (fp)
 		{
 			fprintf(fp, "%s", p_self->info[0].my_ip_address.name);
@@ -1047,6 +1047,12 @@ RC_TYPE dyn_dns_destruct(DYN_DNS_CLIENT *p_self)
 		i++;
 	}
 
+	if (p_self->cache_file != NULL)
+	{
+		free(p_self->cache_file);
+		p_self->cache_file = NULL;
+	}
+
 	/* Save old value, if restarted by SIGHUP */
 	cached_times_since_last_update = p_self->times_since_last_update;
 	cached_num_iterations = p_self->num_iterations;
@@ -1305,7 +1311,7 @@ int dyn_dns_main(DYN_DNS_CLIENT *p_dyndns, int argc, char* argv[])
 	 * DDNS server record, since we might get locked out for abuse, so we "seed"
 	 * each of the DDNS records of our struct with the cached IP# from our cache
 	 * file, or from a regular DNS query. */
-	fp = fopen(DYNDNS_DEFAULT_CACHE_FILE, "r");
+	fp = fopen(p_dyndns->cache_file, "r");
 	if (!fp)
 	{
 		struct addrinfo hints;

--- a/src/inadyn_cmd.c
+++ b/src/inadyn_cmd.c
@@ -1158,6 +1158,7 @@ RC_TYPE get_config_data(DYN_DNS_CLIENT *p_self, int argc, char** argv)
 {
 	int i;
 	RC_TYPE rc = RC_OK;
+	int cache_file_len;
 
 	do
 	{
@@ -1257,6 +1258,27 @@ RC_TYPE get_config_data(DYN_DNS_CLIENT *p_self, int argc, char** argv)
 
 		/* Forced update */
 		p_self->forced_update_times = p_self->forced_update_period_sec / p_self->sleep_sec;
+
+		/* Cache filename */
+		if (p_self->interface)
+		{
+			cache_file_len = (strlen(DYNDNS_CACHE_FILE) - 2) +
+				strlen(p_self->interface);
+			if ((p_self->cache_file = malloc(cache_file_len + 1)) == NULL)
+			{
+				rc = RC_OUT_OF_MEMORY;
+				break;
+			}
+			if (snprintf(p_self->cache_file, cache_file_len + 1,
+				     DYNDNS_CACHE_FILE,
+				     p_self->interface) != cache_file_len)
+			{
+				rc = RC_ERROR;
+				break;
+			}
+		}
+		else
+			p_self->cache_file = strdup(DYNDNS_DEFAULT_CACHE_FILE);
 	}
 	while (0);
 


### PR DESCRIPTION
Template for cache filename is '%s.cache'. '%s' receives network interface name.
If interface is not specified, inadyn uses default cache filename inadyn.cache.

This patch avoids race condition, when two inadyns uses the same cache file.
