### PR TITLE
Set INADYN_{IP,HOSTNAME,IFACE} environment variables for external command

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -214,7 +214,7 @@ RC_TYPE os_syslog_close(void);
 /**
  * Execute command on successful update.
  */
-RC_TYPE os_shell_execute(char *p_cmd);
+RC_TYPE os_shell_execute(char *p_cmd, char *ip, char *hostname, char *iface);
 
 #ifdef __cplusplus
 }

--- a/man/inadyn.8
+++ b/man/inadyn.8
@@ -188,7 +188,14 @@ Set interface to bind to. Only on UNIX systems.
 Set pidfile, defaults to
 .Pa /var/run/inadyn/inadyn.pid .
 .It Fl e, -exec Ar SCRIPT
-Full path to external command, or script, to run after a successful DDNS update.
+Full path to external command, or script, to run after a successful
+DDNS update.
+.Ar SCRIPT
+can use following environment variables: INADYN_IP,
+INADYN_HOSTNAME. First environment variable contains new IP address,
+second one - host name alias. INADYN_IFACE is available, if
+.Fl -iface
+option used.
 .It Fl w, -wildcard
 Enable domain name wildcarding for dyndns.org, 3322.org, or easydns.com. Default
 disabled. For

--- a/src/dyndns.c
+++ b/src/dyndns.c
@@ -782,7 +782,10 @@ static RC_TYPE do_update_alias_table(DYN_DNS_CLIENT *p_self)
 			/* Run external command hook on update. */
 			if (p_self->external_command)
 			{
-				os_shell_execute(p_self->external_command);
+				os_shell_execute(p_self->external_command,
+						 p_self->info[0].my_ip_address.name,
+						 p_self->info[0].alias_info[0].names.name,
+						 p_self->interface);
 			}
 		}
 	}

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -24,6 +24,7 @@
 #include "dyndns.h"
 
 #ifdef UNIX_OS
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
 
@@ -49,7 +50,7 @@ RC_TYPE os_ip_support_cleanup(void)
     return RC_OK;
 }
 
-RC_TYPE os_shell_execute(char * p_cmd)
+RC_TYPE os_shell_execute(char *p_cmd, char *ip, char *hostname, char *iface)
 {
 	RC_TYPE rc = RC_OK;
 	int child;
@@ -58,6 +59,10 @@ RC_TYPE os_shell_execute(char * p_cmd)
 	switch (child)
 	{
 		case 0: /* child */
+			setenv("INADYN_IP", ip, 1);
+			setenv("INADYN_HOSTNAME", hostname, 1);
+			if (iface)
+				setenv("INADYN_IFACE", iface, 1);
 			execl("/bin/sh", "sh", "-c", p_cmd, (char *) 0);
 			exit(1);
 			break;


### PR DESCRIPTION
External command can use following environment variables: INADYN_IP,
INADYN_HOSTNAME. First environment variable contains new IP address,
second one - host name alias. INADYN_IFACE is available, if --iface
option used.
