### PR TITLE
Freedns "invalid update URL"

### DIFF
--- a/include/errorcode.h
+++ b/include/errorcode.h
@@ -67,6 +67,8 @@ typedef enum
 	RC_FILE_IO_READ_ERROR = 0x71,
 	RC_FILE_IO_OUT_OF_BUFFER = 0x72,
 
+	RC_NO_HASH_SPECIFIED = 0x73,
+
 	RC_RESTART = 0xff,
 } RC_TYPE;
 

--- a/src/errorcode.c
+++ b/src/errorcode.c
@@ -69,6 +69,8 @@ static const ERROR_NAME global_error_table[]  =
 	{RC_FILE_IO_READ_ERROR,			"RC_FILE_IO_READ_ERROR"},
 	{RC_FILE_IO_OUT_OF_BUFFER,		"RC_FILE_IO_OUT_OF_BUFFER"},
 
+	{RC_NO_HASH_SPECIFIED,		"RC_NO_HASH_SPECIFIED"},
+
 	{RC_OK,					 NULL}
 };
 


### PR DESCRIPTION
I'm getting "ERROR: Invalid update URL (2)" every time I try to update a freedns.afraid.org address which worked previously. Also, when trying to use "--verbose" or "-V" to get more information, neither seem to work - I get a variety of different error messages when I try any combination of -V/--verbose either with a no number after them, a number (1-5) immediately after them (no space), a number after a space after them (1-5) or "=5" after them.
