### PR TITLE
Fix strict-aliasing warnings in md5.c

### DIFF
--- a/include/md5.h
+++ b/include/md5.h
@@ -79,7 +79,11 @@ struct md5_ctx
 
   md5_uint32 total[2];
   md5_uint32 buflen;
-  char buffer[128];
+  union
+  {
+    char buffer[128];
+    md5_uint32 buffer32[32];
+  };
 };
 
 /*

--- a/src/md5.c
+++ b/src/md5.c
@@ -96,9 +96,9 @@ md5_finish_ctx (struct md5_ctx *ctx, void *resbuf)
   memcpy (&ctx->buffer[bytes], fillbuf, pad);
 
   /* Put the 64-bit file length in *bits* at the end of the buffer.  */
-  *(md5_uint32 *) &ctx->buffer[bytes + pad] = SWAP (ctx->total[0] << 3);
-  *(md5_uint32 *) &ctx->buffer[bytes + pad + 4] = SWAP ((ctx->total[1] << 3) |
-							(ctx->total[0] >> 29));
+  ctx->buffer32[(bytes + pad) / 4] = SWAP (ctx->total[0] << 3);
+  ctx->buffer32[(bytes + pad + 4) / 4] = SWAP ((ctx->total[1] << 3) |
+					       (ctx->total[0] >> 29));
 
   /* Process last bytes.  */
   md5_process_block (ctx->buffer, bytes + pad + 8, ctx);


### PR DESCRIPTION
Fix from [glibc commit 7dc6bd90c56 "Use union to avoid casts in code to
store results of hashsum computations"](http://sourceware.org/git/?p=glibc.git;a=commit;h=7dc6bd90c569c49807462b0740b18e32fab4d8b7)
