### PR TITLE
Use minus sign instead of hyphen

### DIFF
--- a/man/inadyn.conf.5
+++ b/man/inadyn.conf.5
@@ -43,15 +43,15 @@ The \\ character can be used as an escape character.
 .Ss 1.  Config file with long options
 # Some comments about the inadyn conf file
 .br
---username test
+\-\-username test
 .br
---password test
+\-\-password test
 .br
---period 60
+\-\-period 60
 .br
---alias test.homeip.net
+\-\-alias test.homeip.net
 .br
---alias my.second.domain
+\-\-alias my.second.domain
 .Ss 2.  Config file without Dq \-\-
 username test # user
 .br


### PR DESCRIPTION
It is needed for correct formatting in UTF-8 locale.
See http://lists.debian.org/debian-devel/2003/debian-devel-200303/msg01481.html
for details.
