### PR TITLE
Initialize 'timeout' variable

### DIFF
--- a/src/http_client.c
+++ b/src/http_client.c
@@ -69,7 +69,8 @@ RC_TYPE http_client_destruct(HTTP_CLIENT *p_self, int num)
 /* Set default TCP specififc params */
 static RC_TYPE local_set_params(HTTP_CLIENT *p_self)
 {
-	int timeout, port;
+	int timeout = 0;
+	int port;
 
 	http_client_get_remote_timeout(p_self, &timeout);
 	if (timeout == 0)


### PR DESCRIPTION
Hi,

There is compile fix for:

```
$ make
  CC      src/base64.o
  CC      src/md5.o
  CC      src/dyndns.o
  CC      src/errorcode.o
  CC      src/get_cmd.o
  CC      src/http_client.o
src/http_client.c: In function ‘http_client_init’:
src/http_client.c:75:14: error: ‘timeout’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (timeout == 0)
              ^
src/http_client.c:72:6: note: ‘timeout’ was declared here
  int timeout, port;
      ^
cc1: all warnings being treated as errors
make: *** [src/http_client.o] Error 1
```

```
$ gcc --version
gcc (Debian 4.8.1-3) 4.8.1
```
