### PR TITLE
Fix for all updates failing to DDNS service provides when using inadyn 1.99.3

### DIFF
--- a/src/dyndns.c
+++ b/src/dyndns.c
@@ -1133,7 +1133,8 @@ static RC_TYPE get_encoded_user_passwd(DYN_DNS_CLIENT *p_self)
 			break;
 		}
 
-		/*encode*/
+		/* query required buffer size for base64 encoded data */
+		base64_encode(NULL, &dlen, (unsigned char *)p_tmp_buff, strlen(p_tmp_buff));
 		p_b64_buff = (char *)malloc(dlen);
 		if (p_b64_buff == NULL)
 		{
@@ -1142,6 +1143,7 @@ static RC_TYPE get_encoded_user_passwd(DYN_DNS_CLIENT *p_self)
 			break;
 		}
 
+		/* encode */
 		rc2 = base64_encode((unsigned char *)p_b64_buff, &dlen, (unsigned char *)p_tmp_buff, strlen(p_tmp_buff));
 		if (rc2 != 0)
 		{


### PR DESCRIPTION
Base64 encoding of the HTTP basic authorisation token was broken
resulting in updates being rejected with 401 Unauthorised.  Fixes
attached with detailed explanation.

Thanks,
Mike

Log file fragment:
(Hostname and IP address edited)

Tue Aug  6 20:33:09 2013: Sending IP# update to DDNS server, connecting to dynupdate.no-ip.com(8.23.224.120)
Tue Aug  6 20:33:10 2013: Sending alias table update to DDNS server:
Tue Aug  6 20:33:10 2013: GET /nic/update?hostname=myhostname.no-ip.biz&myip=11.22.33.44 HTTP/1.0
Host: dynupdate.no-ip.com
Authorization: Basic <D0>3t
User-Agent: inadyn/1.99.3 troglobit@gmail.com

Tue Aug  6 20:33:10 2013: Fatal error in DDNS server response:
Tue Aug  6 20:33:10 2013: [401 Unauthorized] This service requires basic http authentication
Tue Aug  6 20:33:10 2013: DDNS server response:
Tue Aug  6 20:33:10 2013: HTTP/1.0 401 Unauthorized
