### PR TITLE
Fix SNI, issue #63 (tested with OpenSSL, maybe needs fixes for gnutls)

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -49,6 +49,7 @@
 #define RC_HTTPS_NO_SSL_SUPPORT                     35
 #define RC_HTTPS_SEND_ERROR                         36
 #define RC_HTTPS_RECV_ERROR                         37
+#define RC_HTTPS_SNI_ERROR                          38
 
 #define RC_DYNDNS_BUFFER_TOO_SMALL                  40
 #define RC_DYNDNS_INVALID_IP_ADDR_IN_HTTP_RESPONSE  41

--- a/include/http.h
+++ b/include/http.h
@@ -26,6 +26,7 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <openssl/tls1.h>
 #include <openssl/err.h>
 #elif defined(CONFIG_GNUTLS)
 #include <gnutls/openssl.h>


### PR DESCRIPTION
compiles and works ok for OpenSSL

for gnutls, could not build it:

 LINK    src/inadyn
/usr/bin/ld: src/ssl.o: undefined reference to symbol 'gnutls_server_name_set@@GNUTLS_1_4'
//usr/lib/x86_64-linux-gnu/libgnutls.so.26: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: **\* [src/inadyn] Error 1

also please check my C, it is a bit rusty.
