### PR TITLE
Missing include that prevents proper SSL support

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -21,6 +21,8 @@
 #ifndef INADYN_HTTP_H_
 #define INADYN_HTTP_H_
 
+#include "config.h"
+
 #if defined(CONFIG_OPENSSL)
 #include <openssl/crypto.h>
 #include <openssl/x509.h>


### PR DESCRIPTION
The header file http.h uses macro definitions defined (or not) in config.h, but does not include config.h beforehand.
This caused a segfault for me, because a pointer value was incorrectly overwritten in the code.
