### PR TITLE
Fix manpage

### DIFF
--- a/man/inadyn.8
+++ b/man/inadyn.8
@@ -395,7 +395,7 @@ to exit gracefully.
 Same as TERM.
 .It USR1
 Force update now, even if the IP address has not changed.  Works in
-tandem with --fake-address
+tandem with \-\-fake-address
 .It USR2
 Check IP address change now. Useful when a new DHCP/PPPoE lease or new
 gateway is received.  Please note that


### PR DESCRIPTION
Hi,

Please merge. This PR fixes following:

```
$ lintian -I inadyn_1.99.9-1_i386.changes 
I: inadyn: hyphen-used-as-minus-sign usr/share/man/man8/inadyn.8.gz:398
```
