### PR TITLE
Fix Duck DNS support

### DIFF
--- a/plugins/duckdns.c
+++ b/plugins/duckdns.c
@@ -79,7 +79,7 @@ static int response(http_trans_t *trans, ddns_info_t *UNUSED(info), ddns_alias_t
 
 	DO(http_status_valid(trans->status));
 
-	if (strstr(resp, "OK") || strstr(resp, "good"))
+	if (strstr(resp, "KO") || strstr(resp, "OK") || strstr(resp, "good"))
 		return RC_OK;
 
 	return RC_DYNDNS_RSP_NOTOK;


### PR DESCRIPTION
Duck DNS changed their response value to "KO". Not sure whether this is
a typo from their part, but a comparison for this value has been added.