### PR TITLE
Some systems need <time.h> to pull in struct timeval

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,5 +111,8 @@ AC_FUNC_FORK
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_SELECT_ARGTYPES
 AC_CHECK_FUNCS([atexit memset poll socket strerror])
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+  AC_MSG_ERROR([unable to find the dlopen() function])
+])
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,4 +29,4 @@ inadyn_SOURCES += ../plugins/common.c		../plugins/dyndns.c	\
 inadyn_CFLAGS   = -W -Wall -Wextra -std=gnu99
 inadyn_CFLAGS  += -D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE
 inadyn_CFLAGS  +=      $(lite_CFLAGS) $(confuse_CFLAGS) $(OpenSSL_CFLAGS) $(GnuTLS_CFLAGS)
-inadyn_LDADD    = -ldl $(lite_LIBS)   $(confuse_LIBS)   $(OpenSSL_LIBS)   $(GnuTLS_LIBS)
+inadyn_LDADD    = $(lite_LIBS)   $(confuse_LIBS)   $(OpenSSL_LIBS)   $(GnuTLS_LIBS)

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -23,6 +23,7 @@
 #include <poll.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "debug.h"
 #include "tcp.h"


### PR DESCRIPTION
Hopefully a trivial portability fix :)