### PR TITLE
- fix "error: unknown type name ‘va_list’" on some linux distris

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -25,6 +25,7 @@
 #define INADYN_DEBUG_H_
 
 #include "os.h"
+#include <stdarg.h>
 
 extern char *__progname;
 


### PR DESCRIPTION
This adds a missing include to fix above error on some linux distris like opensuse.
Error was introduced in commit cd208ca3640cda64278b743970ce026987d7243c.

```
CC       inadyn-tcp.o
In file included from tcp.c:28:0:../include/debug.h:33:41: error: unknown type name ‘va_list’
void vlogit (int prio, const char *fmt, va_list args);
                                        ^
Makefile:665: recipe for target 'inadyn-tcp.o' failed
make[2]: *** [inadyn-tcp.o] Error 1
```