### PR TITLE
avoid dirname() breaking original pidfile_name

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -180,7 +180,7 @@ int os_check_perms(void)
 			return RC_PIDFILE_EXISTS_ALREADY;
 		}
 
-		pidfile_dir = dirname(pidfile_name);
+		pidfile_dir = dirname(strdupa(pidfile_name));
 		if (access(pidfile_dir, F_OK)) {
 			if (mkpath(pidfile_dir, 0755) && errno != EEXIST) {
 				logit(LOG_ERR, "No write permission to %s, aborting.", pidfile_dir);


### PR DESCRIPTION
with option like --pidfile /var/run/inadyn.pid, error came out: Failed creating pidfile (/var/run): Is a directory