### PR TITLE
Fix Easy DNS plugin api updates

### DIFF
--- a/plugins/easydns.c
+++ b/plugins/easydns.c
@@ -50,8 +50,8 @@ static ddns_system_t plugin = {
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
-	.server_name  = "members.easydns.com",
-	.server_url   = "/dyn/dyndns.php"
+	.server_name  = "api.cp.easydns.com",
+	.server_url   = "/dyn/generic.php"
 };
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)

--- a/plugins/easydns.c
+++ b/plugins/easydns.c
@@ -25,7 +25,7 @@
 
 /*
  * For details, see the excellent support page at easyDNS
- * http://support.easydns.com/tutorials/dynamicUpdateSpecs.php
+ * https://fusion.easydns.com/Knowledgebase/Article/View/102/0/dynamic-dns
  */
 #define EASYDNS_UPDATE_IP_REQUEST					\
 	"GET %s?"							\


### PR DESCRIPTION
This corrects the api usage for the easydns plugin.

I also want to note that their documentation states:

> If you do code a client for easyDNS, please email our [support team](mailto:support@easydns.com) so we can keep you informed of any changes, enhancements, bug fixes etc. Also, please be sure to let us know about your client, which platform it runs on, and where our users can download it so we can add it to our dynamic page.