### PR TITLE
Ignore premature termination in GnuTLS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     packages:
       - tree
       - libconfuse-dev
+      - libgnutls28-dev
   coverity_scan:
     project:
       name: "troglobit/inadyn"

--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ if test "x$ac_enable_ssl" = "xyes"; then
 			])
       AC_DEFINE([CONFIG_OPENSSL], [], [Enable HTTPS support using OpenSSL library])
    else
-      PKG_CHECK_MODULES([GnuTLS], [gnutls])
+      PKG_CHECK_MODULES([GnuTLS], [gnutls >= 3.0])
       LDFLAGS="$LDFLAGS $GnuTLS_LIBS"
       CPPFLAGS="$CPPFLAGS $GnuTLS_CFLAGS"
       AC_CHECK_LIB([gnutls], [gnutls_init], [],

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: inadyn
 Section: net
 Priority: optional
 Maintainer: Joachim Nilsson <troglobit@gmail.com>
-Build-Depends: debhelper (>= 9), dh-systemd, gnutls-dev
+Build-Depends: debhelper (>= 9), dh-systemd, libgnutls28-dev
 Standards-Version: 3.9.6
 Homepage: http://troglobit.com/inadyn.html
 Vcs-Git: git://github.com/troglobit/inadyn.git

--- a/src/gnutls.c
+++ b/src/gnutls.c
@@ -302,8 +302,11 @@ int ssl_recv(http_t *client, char *buf, int buf_len, int *recv_len)
 		ret = gnutls_record_recv(client->ssl, buf, len);
 	} while (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN);
 
-	if (ret < 0)
+	if (ret < 0) {
+		logit(LOG_WARNING, "Failed receiving GnuTLS header response: %s",
+		      gnutls_strerror(ret));
 		return RC_HTTPS_RECV_ERROR;
+	}
 
 	/* Read HTTP body */
 	len = ret;
@@ -316,8 +319,11 @@ int ssl_recv(http_t *client, char *buf, int buf_len, int *recv_len)
 		}
 	} while (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN);
 
-	if (ret < 0)
+	if (ret < 0 && ret != GNUTLS_E_PREMATURE_TERMINATION) {
+		logit(LOG_WARNING, "Failed receiving GnuTLS body response: %s",
+		      gnutls_strerror(ret));
 		return RC_HTTPS_RECV_ERROR;
+	}
 
 	*recv_len = len;
 	logit(LOG_DEBUG, "Successfully received DDNS update response (%d bytes) using HTTPS!", len);


### PR DESCRIPTION
While testing with the update API server from `dynu.com`, the received response was never shown in the debug log. After adding some more logging to `ssl_read()` in `gnutls.c`, it turns out that the server is prematurely closing the connection without a proper TLS shutdown message, which is buggy behaviour.

Googling around, I found some similar reports for other software, where the solution on the client-side is to just ignore the GNUTLS_E_PREMATURE_TERMINATION error, just as OpenSSL does by itself. I'm not aware of the exact security implications, but in this case it fixed my update errors with dynu.com.

The log message should also be implemented in `openssl.c`, but I couldn't yet get my head around their error reporting API, and have not even compiled with OpenSSL for testing.