### PR TITLE
Disable SSL checkip connections for SPDYN service.

### DIFF
--- a/plugins/dyndns.c
+++ b/plugins/dyndns.c
@@ -151,6 +151,7 @@ static ddns_system_t spdyn = {
 
 	.checkip_name = "checkip4.spdyn.de",
 	.checkip_url  = "/",
+	.checkip_ssl  = DDNS_CHECKIP_SSL_UNSUPPORTED,
 
 	.server_name  = "update.spdyn.de",
 	.server_url   = "/nic/update"


### PR DESCRIPTION
As stated in their Wiki, the checkip servers for SPDYN only handle HTTP on port 80.

What confused me after making this edit is that `checkip-ssl` is forced on if a custom `checkip-server` option is specified. The documentation actually makes this clear, but it doesn't sound like the default value (true) would be used when the `checkip-ssl` option is missing.