### PR TITLE
Support IPv6 for checkip and update server connections

### DIFF
--- a/src/gnutls.c
+++ b/src/gnutls.c
@@ -285,7 +285,7 @@ int ssl_send(http_t *client, const char *buf, int len)
 	if (ret < 0)
 		return RC_HTTPS_SEND_ERROR;
 
-	logit(LOG_DEBUG, "Successfully sent DDNS update using HTTPS!");
+	logit(LOG_DEBUG, "Successfully sent HTTPS request!");
 
 	return 0;
 }
@@ -320,7 +320,7 @@ int ssl_recv(http_t *client, char *buf, int buf_len, int *recv_len)
 		return RC_HTTPS_RECV_ERROR;
 
 	*recv_len = len;
-	logit(LOG_DEBUG, "Successfully received DDNS update response (%d bytes) using HTTPS!", len);
+	logit(LOG_DEBUG, "Successfully received HTTPS response (%d bytes)!", len);
 
 	return 0;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -191,7 +191,7 @@ int ssl_send(http_t *client, const char *buf, int len)
 		/* XXX: TODO add SSL_get_error() to figure out why */
 		return RC_HTTPS_SEND_ERROR;
 
-	logit(LOG_DEBUG, "Successfully sent DDNS update using HTTPS!");
+	logit(LOG_DEBUG, "Successfully sent HTTPS request!");
 
 	return 0;
 }
@@ -214,7 +214,7 @@ int ssl_recv(http_t *client, char *buf, int buf_len, int *recv_len)
 	if (*recv_len <= 0)
 		*recv_len = 0;
 	*recv_len += len;
-	logit(LOG_DEBUG, "Successfully received DDNS update response (%d bytes) using HTTPS!", *recv_len);
+	logit(LOG_DEBUG, "Successfully received HTTPS response (%d bytes)!", *recv_len);
 
 	return 0;
 }

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -130,8 +130,8 @@ int tcp_init(tcp_sock_t *tcp, char *msg)
 
 		/* Obtain address(es) matching host/port */
 		memset(&hints, 0, sizeof(struct addrinfo));
-		hints.ai_family = AF_INET;	/* Use AF_UNSPEC to allow IPv4 or IPv6 */
-		hints.ai_socktype = SOCK_DGRAM;	/* Datagram socket */
+		hints.ai_family = AF_UNSPEC;		/* Allow IPv4 or IPv6 */
+		hints.ai_socktype = SOCK_DGRAM;		/* Datagram socket */
 		snprintf(port, sizeof(port), "%d", tcp->port);
 
 		s = getaddrinfo(tcp->remote_host, port, &hints, &servinfo);
@@ -143,7 +143,7 @@ int tcp_init(tcp_sock_t *tcp, char *msg)
 		ai = servinfo;
 
 		while (1) {
-			sd = socket(AF_INET, SOCK_STREAM, 0);
+			sd = socket(ai->ai_family, SOCK_STREAM, 0);
 			if (sd == -1) {
 				logit(LOG_ERR, "Error creating client socket: %s", strerror(errno));
 				rc = RC_TCP_SOCKET_CREATE_ERROR;
@@ -161,7 +161,7 @@ int tcp_init(tcp_sock_t *tcp, char *msg)
 			if (getnameinfo(sa, len, host, sizeof(host), NULL, 0, NI_NUMERICHOST))
 				goto next;
 
-			logit(LOG_INFO, "%s, %sconnecting to %s(%s:%d)", msg, tries ? "re" : "",
+			logit(LOG_INFO, "%s, %sconnecting to %s([%s]:%d)", msg, tries ? "re" : "",
 			      tcp->remote_host, host, tcp->port);
 			if (connect(sd, sa, len)) {
 				tries++;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -131,7 +131,8 @@ int tcp_init(tcp_sock_t *tcp, char *msg)
 		/* Obtain address(es) matching host/port */
 		memset(&hints, 0, sizeof(struct addrinfo));
 		hints.ai_family = AF_UNSPEC;		/* Allow IPv4 or IPv6 */
-		hints.ai_socktype = SOCK_DGRAM;		/* Datagram socket */
+		hints.ai_socktype = SOCK_STREAM;	/* Stream socket */
+		hints.ai_flags = AI_NUMERICSERV;	/* No service name lookup */
 		snprintf(port, sizeof(port), "%d", tcp->port);
 
 		s = getaddrinfo(tcp->remote_host, port, &hints, &servinfo);


### PR DESCRIPTION
This fixes #186 by not filtering for only IPv4 addresses in `getaddrinfo()`. It catches both checkip and DDNS update connections because of their common `tcp_init()` function.

Tested with both IPv4 and IPv6-only checkip servers and verified that with the new code, the update server is connected to via IPv6.