### PR TITLE
Fix validation of provider config sections

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -160,7 +160,7 @@ static int validate_provider(cfg_t *cfg, cfg_opt_t *opt)
 {
 	const char *provider;
 
-	cfg = cfg_opt_getnsec(opt, 0);
+	cfg = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
 	provider = cfg_title(cfg);
 
 	if (!provider) {
@@ -173,7 +173,7 @@ static int validate_provider(cfg_t *cfg, cfg_opt_t *opt)
 
 static int validate_custom(cfg_t *cfg, cfg_opt_t *opt)
 {
-	cfg = cfg_opt_getnsec(opt, 0);
+	cfg = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
 	if (!cfg)
 		return -1;
 

--- a/src/log.c
+++ b/src/log.c
@@ -71,10 +71,10 @@ int log_level(char *arg)
 
 void vlogit(int prio, const char *fmt, va_list args)
 {
-	if (level == INTERNAL_NOPRI)
-		return;
-
-	vsyslog(prio, fmt, args);
+	if (enabled && level != INTERNAL_NOPRI)
+		vsyslog(prio, fmt, args);
+	else if (prio <= level)
+		vfprintf(stderr, fmt, args), fprintf(stderr, "\n");
 }
 
 void logit(int prio, const char *fmt, ...)
@@ -82,10 +82,7 @@ void logit(int prio, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	if (enabled)
-		vlogit(prio, fmt, args);
-	else if (prio <= level)
-		vfprintf(stderr, fmt, args), fprintf(stderr, "\n");
+	vlogit(prio, fmt, args);
 	va_end(args);
 }
 


### PR DESCRIPTION
The `validate_provider()` and `validate_custom()` functions always accessed the first corresponding section, instead of the last one that was parsed.  Use the `cfg_opt_size()` magic as shown in the libconfuse tutorial.

Strangely, I never got to see any message from the corresponding `cfg_error()` call, just a generic `Parse error in test.conf` message.  Commenting the `cfg_set_error_function()` call made it work on stderr.  gdb never even saw the `conf_errfunc()` being called, and I couldn't step through `cfg_set_error_function()`.

Could this be a problem with my libconfuse version? Ubuntu 17.10 has 3.2+really3.0+dfsg-1.