### PR TITLE
openssl library needed to compile on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ They are available from most UNIX distributions as pre-built packages.
 Make sure to install the `-dev` or `-devel` package of the distribution
 packages when building Inadyn.  On Debian/Ubuntu (derivatives):
 
-    $ sudo apt install gnutls-dev libconfuse-dev
+    $ sudo apt install gnutls-dev libconfuse-dev libssl-dev
 
 When building with HTTPS (SSL/TLS) support, make sure to also install
 the `ca-certificates` package on your system, otherwise Inadyn will not


### PR DESCRIPTION
Add an extra build dependency.