### PR TITLE
Homebrew formula and custom tap

### DIFF
--- a/HomebrewFormula/inadyn.rb
+++ b/HomebrewFormula/inadyn.rb
@@ -1,0 +1,36 @@
+class Inadyn < Formula
+  desc "Dynamic DNS client with IPv4, IPv6, and SSL/TLS support"
+  homepage "http://troglobit.com/inadyn.html"
+  head "https://github.com/troglobit/inadyn.git"
+  version "2.4-HEAD"
+
+  depends_on "autoconf"   => :build
+  depends_on "automake"   => :build
+  depends_on "cmake"      => :build
+  depends_on "confuse"
+  depends_on "gnutls"
+  depends_on "libtool"    => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    mkdir_p buildpath/"inadyn/m4"
+    system "autoreconf", "-W", "portability", "-vif" unless build.stable?
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--localstatedir=#{var}"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOF
+    Place your DDNS provider's parameters in #{etc}/inadyn.conf
+
+    Sample configurations can be found in #{HOMEBREW_PREFIX}/share/doc/inadyn/examples/
+  EOF
+  end
+
+  test do
+    system "#{sbin}/inadyn", "--check-config", "--config=#{HOMEBREW_PREFIX}/share/doc/inadyn/examples/inadyn.conf"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ last example above.
 Build & Install
 ---------------
 
+### Homebrew (macOS)
+
+To run the latest stable version on macOS, type:
+
+    brew install inadyn
+
+To run the latest version from the master branch, install the git tap instead:
+
+    brew install --HEAD troglobit/inadyn/inadyn
+
+Either of these will install all dependencies.
+
+### Building from Source
+
 In-A-Dyn requires a few libraries to build.  The build system searches
 for them, in their required versions, using the `pkg-config` tool:
 


### PR DESCRIPTION
The `HomebrewFormula` path will be searched automatically by Homebrew. allowing the commands as shown below.

The "stable version" command won't work until the next release is pushed.

fixes #140 