### PR TITLE
Do not try to resolve the special hostname all.dnsomatic.com

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -85,7 +85,8 @@ static void read_one(ddns_alias_t *alias, int nonslookup)
 	cache_file(alias->name, path, sizeof(path));
 	fp = fopen(path, "r");
 	if (!fp) {
-		if (nonslookup)
+		/* Exception for dnsomatic's special global hostname */
+		if (nonslookup || !strcmp(alias->name, "all.dnsomatic.com"))
 			return;
 
 		/* Try a DNS lookup of our last known IP#. */


### PR DESCRIPTION
This hostname is a special case that tells dnsomatic to update
all hostnames linked to the account.  Trying to resolve it causes a
"Failed resolving hostname all.dnsomatic.com: Name or service not known"
error to be logged.