### PR TITLE
Sync up with accepted Homebrew formula

### DIFF
--- a/HomebrewFormula/inadyn.rb
+++ b/HomebrewFormula/inadyn.rb
@@ -1,33 +1,37 @@
 class Inadyn < Formula
   desc "Dynamic DNS client with IPv4, IPv6, and SSL/TLS support"
-  homepage "http://troglobit.com/inadyn.html"
-  head "https://github.com/troglobit/inadyn.git"
-  version "2.4-HEAD"
+  homepage "http://troglobit.com/projects/inadyn/"
+  url "https://github.com/troglobit/inadyn/releases/download/v2.5/inadyn-2.5.tar.gz"
+  sha256 "f7faf0be4f0b4bfa1acc811189a9ed0a58bc367e48ea31c283920a2ef27cdc40"
+  version "2.5"
 
-  depends_on "autoconf"   => :build
-  depends_on "automake"   => :build
-  depends_on "cmake"      => :build
+  head do
+    url "https://github.com/troglobit/inadyn.git"
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake"    => :build
+  depends_on "libtool"  => :build
   depends_on "confuse"
   depends_on "gnutls"
-  depends_on "libtool"    => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config"
+
+  # Fix for Sierra with v2.5, remove in next version
+  patch do
+    url "https://github.com/troglobit/inadyn/commit/57bdcc0321b49ee68397c70140d9895655edb06f.diff?full_index=1"
+    sha256 "6d24c3822e7017a471583f5424421d83e6e426b464ca7521db943ecec580eea5"
+  end
 
   def install
     mkdir_p buildpath/"inadyn/m4"
-    system "autoreconf", "-W", "portability", "-vif" unless build.stable?
+    system "autoreconf", "-vif"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--localstatedir=#{var}"
     system "make", "install"
-  end
-
-  def caveats; <<-EOF
-    Place your DDNS provider's parameters in #{etc}/inadyn.conf
-
-    Sample configurations can be found in #{HOMEBREW_PREFIX}/share/doc/inadyn/examples/
-  EOF
   end
 
   test do


### PR DESCRIPTION
This syncs up your tap formula with what they accepted in Homebrew, but retains the ability to build from HEAD for people wanting to track the latest.

When you release a new version just update the SHA and remove the patch ;-)