### PR TITLE
Add IPv4/v6 dual-stack to the configuration

### DIFF
--- a/include/ddns.h
+++ b/include/ddns.h
@@ -38,6 +38,7 @@
 
 /* 2017-01-05: Dyn.com does NOT support HTTPS for checkip */
 #define DYNDNS_MY_IP_SERVER	"checkip.dyndns.com"
+#define DYNDNS_MY_IPV6_SERVER	"checkipv6.dyndns.com"
 #define DYNDNS_MY_CHECKIP_URL	"/"
 #define DYNDNS_MY_IP_SSL        DDNS_CHECKIP_SSL_UNSUPPORTED
 
@@ -81,6 +82,12 @@ typedef enum {
 	CMD_FORCED_UPDATE,
 	CMD_CHECK_NOW,
 } ddns_cmd_t;
+
+/* bit flags for IP Support options */
+#define UPDATE_NONE  0x0000
+#define UPDATE_IPV4  0x0001
+#define UPDATE_IPV6  0x0002
+#define UPDATE_IPV46 0x0003
 
 typedef struct {
 	char           username[USERNAME_LEN];
@@ -126,12 +133,14 @@ typedef struct di {
 
 	/* Address of "What's my IP" checker */
 	ddns_name_t    checkip_name;
+	ddns_name_t    checkip_name_v6;
 	char           checkip_url[SERVER_URL_LEN];
 	int            checkip_ssl; /* checkip server ssl mode */
 	http_t         checkip;
 
 	/* Shell command for "What's my IP" checker */
 	char          *checkip_cmd;
+	char          *checkip_cmd_v6;
 
 	/* Optional local proxy server for this DDNS provider */
 	tcp_proxy_type_t proxy_type;
@@ -141,6 +150,7 @@ typedef struct di {
 	size_t         alias_count;
 
 	int            wildcard;
+	int            address_type; /* Which type of addresses it will accept */
 
 	int            ssl_enabled;
 	int            append_myip; /* For custom setups! */

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -52,8 +52,10 @@ typedef struct ddns_system {
 	rsp_fn_t       response;
 
 	const int      nousername;    /* Provider does not require username='' */
+	const int      address_type;  /* IPv4, IPv6, or both */
 
 	const char    *checkip_name;
+	const char    *checkip_name_v6;
 	const char    *checkip_url;
 	const int      checkip_ssl;
 

--- a/plugins/changeip.c
+++ b/plugins/changeip.c
@@ -43,7 +43,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ip.changeip.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "nic.changeip.com",
 	.server_url   = "/nic/update"
@@ -56,8 +58,10 @@ static ddns_system_t ovh = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "www.ovh.com",
 	.server_url   = "/nic/update"
@@ -70,8 +74,10 @@ static ddns_system_t strato = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "dyndns.strato.com",
 	.server_url   = "/nic/update"

--- a/plugins/cloudxns.c
+++ b/plugins/cloudxns.c
@@ -58,8 +58,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "www.cloudxns.net",
 	.server_url   = "/api2/record"

--- a/plugins/ddnss.c
+++ b/plugins/ddnss.c
@@ -41,8 +41,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "ddnss.de",
 	.server_url   = "/upd.php"

--- a/plugins/dhis.c
+++ b/plugins/dhis.c
@@ -46,8 +46,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "is.dhis.org",
 	.server_url   =  "/?"

--- a/plugins/dnsexit.c
+++ b/plugins/dnsexit.c
@@ -43,7 +43,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ip.dnsexit.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "update.dnsexit.com",
 	.server_url   = "/RemoteUpdate.sv"

--- a/plugins/dnspod.c
+++ b/plugins/dnspod.c
@@ -40,8 +40,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "dnsapi.cn",
 	.server_url   = ""

--- a/plugins/dtdns.c
+++ b/plugins/dtdns.c
@@ -40,7 +40,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "myip.dtdns.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "www.dtdns.com",
 	.server_url   = "/api/autodns.cfm"

--- a/plugins/duckdns.c
+++ b/plugins/duckdns.c
@@ -45,7 +45,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ipv4.wtfismyip.com",
+	.checkip_name_v6 = "ipv6.wtfismyip.com",
 	.checkip_url  = "/text",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "www.duckdns.org",
 	.server_url   = "/update"

--- a/plugins/duiadns.c
+++ b/plugins/duiadns.c
@@ -43,7 +43,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ipv4.duiadns.net",
+	.checkip_name_v6 = "ipv6.duiadns.net",
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "ipv4.duiadns.net",
 	.server_url   = "/dynamic.duia"
@@ -97,4 +99,3 @@ PLUGIN_EXIT(plugin_exit)
  *  c-file-style: "linux"
  * End:
  */
-

--- a/plugins/dyndns.c
+++ b/plugins/dyndns.c
@@ -46,8 +46,10 @@ static ddns_system_t dyndns = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "members.dyndns.org",
 	.server_url   = "/nic/update"
@@ -60,7 +62,9 @@ static ddns_system_t dnsomatic = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "myip.dnsomatic.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "updates.dnsomatic.com",
 	.server_url   = "/nic/update"
@@ -74,8 +78,10 @@ static ddns_system_t dynsip = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "dynsip.org",
 	.server_url   = "/nic/update"
@@ -89,8 +95,10 @@ static ddns_system_t selfhost = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "carol.selfhost.de",
 	.server_url   = "/nic/update"
@@ -103,8 +111,10 @@ static ddns_system_t noip = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ip1.dynupdate.no-ip.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "dynupdate.no-ip.com",
 	.server_url   = "/nic/update"
@@ -117,7 +127,9 @@ static ddns_system_t _3322 = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "bliao.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/ip.phtml",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "members.3322.org",
 	.server_url   = "/dyndns/update"
@@ -131,7 +143,9 @@ static ddns_system_t henet = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "checkip.dns.he.net",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "dyn.dns.he.net",
 	.server_url   = "/nic/update"
@@ -148,8 +162,10 @@ static ddns_system_t tunnelbroker = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "ipv4.tunnelbroker.net",
 	.server_url   = "/nic/update"
@@ -166,8 +182,10 @@ static ddns_system_t spdyn = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "checkip4.spdyn.de",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
 	.checkip_ssl  = DDNS_CHECKIP_SSL_UNSUPPORTED,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "update.spdyn.de",
 	.server_url   = "/nic/update"
@@ -181,7 +199,9 @@ static ddns_system_t nsupdate_info_ipv4 = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ipv4.nsupdate.info",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/myip",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "ipv4.nsupdate.info",
 	.server_url   = "/nic/update"
@@ -198,7 +218,9 @@ static ddns_system_t loopia = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "dns.loopia.se",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/checkip/checkip.php",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "dns.loopia.se",
 	.server_url   = "/XDynDNSServer/XDynDNS.php"
@@ -211,8 +233,10 @@ static ddns_system_t googledomains = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "domains.google.com",
 	.server_url   = "/nic/update"
@@ -225,7 +249,9 @@ static ddns_system_t dynu = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "checkip.dynu.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "api.dynu.com",
 	.server_url   = "/nic/update"

--- a/plugins/dynv6-ipv4.c
+++ b/plugins/dynv6-ipv4.c
@@ -46,8 +46,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "ipv4.dynv6.com",
 	.server_url   =  "/api/update"

--- a/plugins/dynv6.c
+++ b/plugins/dynv6.c
@@ -46,8 +46,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV6,
 
 	.server_name  = "dynv6.com",
 	.server_url   =  "/api/update"

--- a/plugins/easydns.c
+++ b/plugins/easydns.c
@@ -47,8 +47,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "api.cp.easydns.com",
 	.server_url   = "/dyn/generic.php"

--- a/plugins/freedns.c
+++ b/plugins/freedns.c
@@ -44,7 +44,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "freedns.afraid.org",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/dynamic/check.php",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "freedns.afraid.org",
 	.server_url   = "/dynamic/update.php"

--- a/plugins/freemyip.c
+++ b/plugins/freemyip.c
@@ -45,7 +45,9 @@ static ddns_system_t plugin = {
 	.nousername   = 1,	/* Provider does not require username */
 
 	.checkip_name = "ipv4.wtfismyip.com",
+	.checkip_name_v6 = "ipv6.wtfismyip.com",
 	.checkip_url  = "/text",
+	.address_type = UPDATE_IPV46,
 
 	.server_name  = "freemyip.com",
 	.server_url   = "/update"

--- a/plugins/generic.c
+++ b/plugins/generic.c
@@ -51,8 +51,10 @@ static ddns_system_t generic = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "",
 	.server_url   = ""

--- a/plugins/giradns.c
+++ b/plugins/giradns.c
@@ -40,7 +40,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "ipv4.wtfismyip.com",
+	.checkip_name_v6 = "ipv6.wtfismyip.com",
 	.checkip_url  = "/text",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "homeserver.gira.de",
 	.server_url   = "/hsdyndns.php"

--- a/plugins/sitelutions.c
+++ b/plugins/sitelutions.c
@@ -44,8 +44,10 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "www.sitelutions.com",
 	.server_url   = "/dnsup"

--- a/plugins/tunnelbroker.c
+++ b/plugins/tunnelbroker.c
@@ -46,7 +46,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "checkip.dns.he.net",
+	.checkip_name_v6 = "checkip.dns.he.net",
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "ipv4.tunnelbroker.net",
 	.server_url   = "/ipv4_end.php"

--- a/plugins/tzo.c
+++ b/plugins/tzo.c
@@ -46,7 +46,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "echo.tzo.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "rh.tzo.com",
 	.server_url   = "/webclient/tzoperl.html"

--- a/plugins/zerigo.c
+++ b/plugins/zerigo.c
@@ -40,7 +40,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "checkip.zerigo.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "update.zerigo.com",
 	.server_url   = "/dynamic?host="

--- a/plugins/zoneedit.c
+++ b/plugins/zoneedit.c
@@ -42,7 +42,9 @@ static ddns_system_t plugin = {
 	.response     = (rsp_fn_t)response,
 
 	.checkip_name = "dynamic.zoneedit.com",
+	.checkip_name_v6 = DYNDNS_MY_IPV6_SERVER,
 	.checkip_url  = "/checkip.html",
+	.address_type = UPDATE_IPV4,
 
 	.server_name  = "dynamic.zoneedit.com",
 	.server_url   = "/auth/dynamic.html"

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -119,6 +119,12 @@ static int get_req_for_ip_server(ddns_t *ctx, ddns_info_t *info)
 			DYNDNS_CHECKIP_HTTP_REQUEST, info->checkip_url,
 			info->checkip_name.name, info->user_agent);
 }
+static int get_req_for_ipv6_server(ddns_t *ctx, ddns_info_t *info)
+{
+	return snprintf(ctx->request_buf, ctx->request_buflen,
+			DYNDNS_CHECKIP_HTTP_REQUEST, info->checkip_url_v6,
+			info->checkip_name_v6.name, info->user_agent);
+}
 
 /*
  * Send req to IP server and get the response


### PR DESCRIPTION
Add to plugin
  * `address_type` for address types supported
  * `checkip_name_v6` for IPv6 lookup

Add to provider configuration
  * `addrtype` for type of address to submit
  * `checkip_cmd_v6` for IPv6 command to lookup IP

NOTE: This adds the necessary types to the configuration. It does not (yet) change the behavior of the stack. I wanted to stop here and get feedback from @troglobit on whether or not I'm going in the right direction, or if my rusty C skills are making him puke ;-)

When done will address #52 