### PR TITLE
Add Dockerfile for inadyn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:latest as builder
+
+RUN apt update && \
+    apt install -y \
+      automake \
+      gcc \
+      git \
+      gnutls-dev \
+      libconfuse-dev \
+      libtool \
+      make && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/troglobit/inadyn.git
+WORKDIR inadyn
+RUN ./autogen.sh && ./configure && make install
+
+FROM debian:latest
+
+RUN apt update && \
+    apt install -y \
+      ca-certificates \
+      libconfuse1 \
+      libgnutls30 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/sbin/inadyn /usr/bin/inadyn
+ENTRYPOINT [ "/usr/bin/inadyn" ]
+CMD [ "--foreground" ]

--- a/README.md
+++ b/README.md
@@ -450,6 +450,13 @@ Building from GIT requires, at least, the previously mentioned library
 dependencies.  GIT sources are a moving target and are not recommended
 for production systems, unless you know what you are doing!
 
+Building with Docker
+--------------------
+
+A Dockerfile is provided to simplify building and running `inadyn`.
+
+    docker build -t inadyn:latest .
+    docker run --rm --mount "type=bind,source=$PWD/inadyn.conf,target=/usr/local/etc/inadyn.conf" inadyn:latest
 
 Origin & References
 -------------------


### PR DESCRIPTION
Adding a Dockerfile simplifies deployment of inadyn without having to worry about installing dependencies or out-of-date packages.