### PR TITLE
Base Dockerfile off of Alpine linux.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,23 @@
-FROM debian:latest as builder
+FROM alpine:latest as builder
 
-RUN apt update && \
-    apt install -y \
-      automake \
-      gcc \
-      git \
-      gnutls-dev \
-      libconfuse-dev \
-      libtool \
-      make && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add \
+  autoconf \
+  automake \
+  confuse-dev \
+  gcc \
+  git \
+  gnutls-dev \
+  libc-dev \
+  libtool \
+  make
 
 RUN git clone https://github.com/troglobit/inadyn.git
 WORKDIR inadyn
 RUN ./autogen.sh && ./configure && make install
 
-FROM debian:latest
-
-RUN apt update && \
-    apt install -y \
-      ca-certificates \
-      libconfuse1 \
-      libgnutls30 && \
-    rm -rf /var/lib/apt/lists/*
+FROM alpine:latest
 
 COPY --from=builder /usr/local/sbin/inadyn /usr/bin/inadyn
+
 ENTRYPOINT [ "/usr/bin/inadyn" ]
 CMD [ "--foreground" ]


### PR DESCRIPTION
Follow-up from #225. I had to explicitly install the `libc-dev` package to get the configure scripts to work on Alpine. Previous error was complaining "C compiler cannot create executables."

This reduces size of image from ~112MB to ~5MB.