### PR TITLE
Fix missing shared libraries in Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN ./autogen.sh && ./configure && make install
 
 FROM alpine:latest
 
+RUN apk --no-cache add \
+  ca-certificates \
+  confuse \
+  gnutls
+
 COPY --from=builder /usr/local/sbin/inadyn /usr/bin/inadyn
 
 ENTRYPOINT [ "/usr/bin/inadyn" ]


### PR DESCRIPTION
See the comment in #226. 

The gnutls and libconfuse shared librares are missing in the second stage. Inadyn can't start without them and a certificate store provided by the ca-certificates package.

Sorry about polluting the commit history. The current image runs fine up until you try to load a config, which I've tried with this branch.