### PR TITLE
Fix compilation without deprecated OpenSSL 1.1 APIs

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -25,17 +25,21 @@
 
 int ssl_init(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	SSL_library_init();
 	SSL_load_error_strings();
 	OpenSSL_add_all_algorithms();
-
+#endif
+	
 	return 0;
 }
 
 void ssl_exit(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ERR_free_strings();
 	EVP_cleanup();
+#endif
 }
 
 static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)


### PR DESCRIPTION
Initialization and Deinitialization are deprecated in OpenSSL 1.1. Fixes
compilation when deprecated APIs are compile-time disabled.