### PR TITLE
Add Yandex PDD (Yandex.Connect) plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ examples.
 * <https://www.dnspod.cn>
 * <https://www.dynu.com>
 * <https://www.selfhost.de>
+* <https://connect.yandex.ru>
 
 In-A-Dyn defaults to HTTPS, but not all providers may support this, so
 try disabling SSL for the update (`ssl = false`) or the checkip phase

--- a/include/ddns.h
+++ b/include/ddns.h
@@ -62,7 +62,7 @@
 
 /* local configs */
 #define USERNAME_LEN                      50      /* chars */
-#define PASSWORD_LEN                      50      /* chars */
+#define PASSWORD_LEN                      256     /* chars */
 #define SERVER_NAME_LEN                   256     /* chars */
 #define SERVER_URL_LEN                    256     /* chars */
 #ifdef INET6_ADDRSTRLEN

--- a/include/jsmn.h
+++ b/include/jsmn.h
@@ -1,0 +1,468 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef JSMN_H
+#define JSMN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1,
+  JSMN_ARRAY = 2,
+  JSMN_STRING = 3,
+  JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
+ */
+typedef struct {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
+#ifdef JSMN_PARENT_LINKS
+  int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string.
+ */
+typedef struct {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
+ * a single JSON object.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens);
+
+#ifndef JSMN_HEADER
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+  tok->parent = -1;
+#endif
+  return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
+
+  start = parser->pos;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
+#endif
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
+#ifdef JSMN_STRICT
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+#endif
+
+found:
+  if (tokens == NULL) {
+    parser->pos--;
+    return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
+
+  int start = parser->pos;
+
+  parser->pos++;
+
+  /* Skip starting quote */
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
+
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+      token->parent = parser->toksuper;
+#endif
+      return 0;
+    }
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
+
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
+        }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
+    for (i = parser->toknext - 1; i >= 0; i--) {
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Creates a new parser based over a given buffer with an array of tokens
+ * available.
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
+}
+
+#endif /* JSMN_HEADER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSMN_H */

--- a/man/inadyn.conf.5
+++ b/man/inadyn.conf.5
@@ -296,6 +296,8 @@ by Hurricane Electric.
 .Aq https://www.dynu.com
 .It Cm default@selfhost.de
 .Aq https://www.selfhost.de
+.It Cm default@pdd.yandex.ru
+.Aq https://connect.yandex.ru
 .El
 .It Cm custom some@identifier {}
 Specific to the custom provider section are the following settings:

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -5,4 +5,4 @@ inadyn_SOURCES += common.c	dyndns.c	changeip.c	\
 		  generic.c	sitelutions.c	tunnelbroker.c	\
 		  tzo.c		zoneedit.c	zerigo.c	\
 		  dhis.c	dynv6.c		dynv6-ipv4.c	\
-		  ddnss.c
+		  ddnss.c	yandex.c

--- a/plugins/yandex.c
+++ b/plugins/yandex.c
@@ -1,0 +1,341 @@
+/* Plugin for Yandex PDD (Yandex.Connect)
+ *
+ * Copyright (C) 2017 https://github.com/dmitrodem
+ * Copyright (C) 2019 Timur Birsh <taem@linukz.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, visit the Free Software Foundation
+ * website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#include "plugin.h"
+#include "jsmn.h"
+
+#define YANDEX_GET_REQUEST						\
+	"GET %s "							\
+	"HTTP/1.1\r\n"							\
+	"Host: %s\r\n"							\
+	"PddToken: %s\r\n"						\
+	"User-Agent: %s\r\n\r\n"
+
+#define YANDEX_POST_REQUEST						\
+	"POST %s "							\
+	"HTTP/1.1\r\n"							\
+	"Host: %s\r\n"							\
+	"PddToken: %s\r\n"						\
+	"User-Agent: %s\r\n"						\
+	"Content-Length: %i\r\n"					\
+	"Content-Type: application/x-www-form-urlencoded\r\n\r\n"	\
+	"%s"
+
+static int request  (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
+static int response (http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);
+
+static ddns_system_t plugin = {
+	.name         = "default@pdd.yandex.ru",
+
+	.request      = (req_fn_t)request,
+	.response     = (rsp_fn_t)response,
+
+	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
+	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+
+	.server_name  = "pddimp.yandex.ru:443",
+	.server_url   = "/dynamic/update.php"
+};
+
+// XXX: please increase if not enough
+#define TOKENS_EXPECTED		4096
+
+static jsmntok_t *get_tokens(const char *response, int *n) {
+	jsmn_parser *p;
+	jsmntok_t   *t;
+	int	     r;
+
+	p = malloc(sizeof(p));
+	if (!p) {
+		logit(LOG_ERR, "Not enough memory\n");
+		return NULL;
+	}
+	t = malloc(sizeof(t) * TOKENS_EXPECTED);
+	if (!t) {
+		logit(LOG_ERR, "Not enough memory\n");
+		free(p);
+		return NULL;
+	}
+
+	jsmn_init(p);
+	r = jsmn_parse(p, response, strlen(response), t, TOKENS_EXPECTED);
+	free(p);
+	*n = r;
+	if (r < 0){
+		logit(LOG_ERR, "Failed to parse JSON");
+		free(t);
+		return NULL;
+	}
+	if ((r < 1) || (t[0].type != JSMN_OBJECT)) {
+		logit(LOG_ERR, "JSON object expected");
+		free(t);
+		return NULL;
+	}
+
+	return t;
+}
+
+static int jsoneq(const char *json, jsmntok_t *tok, const char *s) {
+	if (tok->type == JSMN_STRING && (int) strlen(s) == tok->end - tok->start &&
+			strncmp(json + tok->start, s, tok->end - tok->start) == 0) {
+		return 0;
+	}
+
+	return -1;
+}
+
+static int success(const char *response) {
+	jsmntok_t *t;
+	int	   n, i;
+	int	   retval = 0;
+
+	t = get_tokens(response, &n);
+	if (!t)
+		return 0;
+
+	for (i = 1; i < n-1; i++) {
+		jsmntok_t *tok = &t[i];
+		if (jsoneq(response, tok, "success") == 0) {
+			if (jsoneq(response, tok + 1, "ok") == 0) {
+				retval = 1;
+				goto out;
+			}
+		}
+	}
+
+out:
+	free(t);
+	return retval;
+}
+
+static int get_record_id(const char *response, const char *subdomain){
+	jsmntok_t *t;
+	int	   n, i;
+	int	   record_id = 0;
+	int	   id_keyword_found = 0;
+
+	enum {
+		ST_UNKNOWN,
+		ST_FIND_RECORDS,
+		ST_FIND_RECORD_ID
+	} state = ST_UNKNOWN;
+
+	enum {
+		SUBDOMAIN_NONE,
+		SUBDOMAIN_KEYWORD,
+		SUBDOMAIN_VALUE
+	} subdomain_field;
+
+	enum {
+		TYPE_NONE,
+		TYPE_KEYWORD,
+		TYPE_VALUE
+	} type_field;
+
+	t = get_tokens(response, &n);
+	if (!t)
+		return -1;
+
+	for (i = 1; i < n; i++) {
+		jsmntok_t *tok = &t[i];
+
+		switch (tok->type) {
+		case JSMN_STRING:
+		case JSMN_PRIMITIVE:
+			if (jsoneq(response, tok, "records") == 0) {
+				state = ST_FIND_RECORDS;
+				break;
+			}
+
+			if (state != ST_FIND_RECORD_ID)
+				break;
+
+			if (jsoneq(response, tok, "subdomain") == 0) {
+				subdomain_field = SUBDOMAIN_KEYWORD;
+				break;
+			}
+
+			if (jsoneq(response, tok, "type") == 0) {
+				type_field = TYPE_KEYWORD;
+				break;
+			}
+
+			if (jsoneq(response, tok, "record_id") == 0) {
+				id_keyword_found = 1;
+				break;
+			}
+
+			if ((subdomain_field == SUBDOMAIN_KEYWORD) &&
+					(jsoneq(response, tok, subdomain)) == 0)
+				subdomain_field = SUBDOMAIN_VALUE;
+
+			if ((type_field == TYPE_KEYWORD) &&
+					(jsoneq(response, tok, "A")) == 0)
+				type_field = TYPE_VALUE;
+
+			if (id_keyword_found) {
+				char buf[129]; // additional byte for \0
+				size_t n = tok->end - tok->start;
+
+				id_keyword_found = 0;
+				if (n > sizeof(buf) - 1)
+					break;
+
+				memset(buf, 0, sizeof(buf));
+				strncpy(buf, response + tok->start, n);
+				record_id = strtol(buf, NULL, 10);
+			}
+
+			if (subdomain_field == SUBDOMAIN_VALUE &&
+					type_field == TYPE_VALUE &&
+					record_id > 0) {
+				free(t);
+				return record_id;
+			}
+
+			break;
+		case JSMN_ARRAY:
+			if (state != ST_FIND_RECORDS)
+				break;
+
+			state = ST_FIND_RECORD_ID;
+			break;
+		case JSMN_OBJECT:
+			if (state != ST_FIND_RECORD_ID)
+				break;
+
+			subdomain_field  = SUBDOMAIN_NONE;
+			type_field	 = TYPE_NONE;
+			id_keyword_found = 0;
+			break;
+		}
+	}
+
+	free(t);
+
+	if (state != ST_FIND_RECORD_ID) {
+		logit(LOG_ERR, "Got JSON document that cannot understand\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias) {
+	http_t	     client;
+	http_trans_t trans;
+	char	     url[512];
+	char	     *resp;
+	int	     record_id;
+	int	     len;
+	int	     rc = 0;
+
+	do {
+		TRY(http_construct(&client));
+
+		http_set_port(&client, info->server_name.port);
+		http_set_remote_name(&client, info->server_name.name);
+
+		client.ssl_enabled = info->ssl_enabled;
+		TRY(http_init(&client, "Trying to get record_id"));
+
+		snprintf(url, sizeof(url), "/api2/admin/dns/list?domain=%s",
+			 info->creds.username);
+
+		trans.req_len = snprintf(ctx->request_buf, ctx->request_buflen,
+					 YANDEX_GET_REQUEST, url,
+					 info->server_name.name,
+					 info->creds.password,
+					 info->user_agent);
+		trans.req = ctx->request_buf;
+		trans.rsp = ctx->work_buf;
+		trans.max_rsp_len = ctx->work_buflen - 1;
+
+		rc  = http_transaction(&client, &trans);
+		rc |= http_exit(&client);
+
+		http_destruct(&client, 1);
+
+		if (rc)
+			break;
+
+		TRY(http_status_valid(trans.status));
+		resp = trans.rsp_body;
+
+		logit(LOG_DEBUG, "Yandex response: %s\n", resp);
+
+		if (!success(resp))
+			break;
+
+		record_id = get_record_id(resp, alias->name);
+
+		if (record_id < 0)
+			break;
+
+		if (record_id > 0) {
+			logit(LOG_INFO, "Updating record, id = %i", record_id);
+			len = snprintf(url, sizeof(url),
+					"domain=%s&record_id=%i&subdomain=%s&content=%s",
+					info->creds.username, record_id, alias->name,
+					alias->address);
+		} else {
+			logit(LOG_INFO, "Creating record");
+			len = snprintf(url, sizeof(url),
+					"domain=%s&type=A&subdomain=%s&content=%s",
+					info->creds.username, alias->name,
+					alias->address);
+		}
+
+		return snprintf(ctx->request_buf, ctx->request_buflen,
+				YANDEX_POST_REQUEST,
+				record_id > 0 ? "/api2/admin/dns/edit"
+					      : "/api2/admin/dns/add",
+				info->server_name.name,
+				info->creds.password,
+				info->user_agent,
+				len, url);
+	} while (0);
+
+	return -1;
+}
+
+static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias) {
+	char *resp = trans->rsp_body;
+
+	DO(http_status_valid(trans->status));
+
+	if (success(resp))
+		return 0;
+
+	return RC_DDNS_RSP_NOTOK;
+}
+
+PLUGIN_INIT(plugin_init)
+{
+	plugin_register(&plugin);
+}
+
+PLUGIN_EXIT(plugin_exit)
+{
+	plugin_unregister(&plugin);
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,4 +36,4 @@ inadyn_SOURCES  += ../plugins/common.c		../plugins/changeip.c	\
 		   ../plugins/sitelutions.c				\
 		   ../plugins/tunnelbroker.c	../plugins/tzo.c	\
 		   ../plugins/zoneedit.c	../plugins/zerigo.c	\
-		   ../plugins/dnspod.c
+		   ../plugins/dnspod.c		../plugins/yandex.c


### PR DESCRIPTION
Hi Joachim,

Could you please review and merge these changes. As per issue #250.
Thanks.

Changes:
 * increase PASSWORD_LEN to 256 as per PddToken length.
 * add Jsmn header only library for JSON processing.

Config notes:
 * username should be your domain managed by Yandex DNS.
 * password is your PddToken.
 * in the hostname parameter please put subdomain (not FQDN).

It should be noted that if hostname does not exist in DNS,
plugin will add it.

For more info please see Yandex PDD API documentation
https://tech.yandex.ru/pdd/doc/concepts/api-dns-docpage/.

Based on the work by https://github.com/dmitrodem.

Signed-off-by: Timur Birsh <taem@linukz.org>