### PR TITLE
Cloudflare: extract zone name from FQDN instead of username

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,8 @@ This looks for the default `.conf` file, to check any file, use:
          hostname = yourhost.example.com
     }
 	
-	# Note: username is your email, then the zone you are updating, separated by a slash.
 	provider cloudflare.com {
-         username = your_username/zone_name
+         username = your_email
          password = your_api_token
          hostname = yourhost.example.com
     }


### PR DESCRIPTION
It occurred to me it's silly to put the zone name in the username when hostnames can just be FQDNs and thus contain the zone. The config example already tells you to do this, and it's actually currently wrong and will cause the hostname to not be found, so this fixes both of those things.