### PR TITLE
Add the ability to specify command line options to inadyn in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ RUN apk --no-cache add \
   confuse \
   gnutls
 
-ENTRYPOINT [ "inadyn" ]
-CMD [ "--foreground" ]
+ENV INADYN_OPTS=""
+
+ENTRYPOINT [ "sh", "-c", "inadyn", "--foreground", $INADYN_OPTS]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN apk --no-cache add \
 
 ENV INADYN_OPTS=""
 
-ENTRYPOINT [ "sh", "-c", "inadyn", "--foreground", $INADYN_OPTS]
+ENTRYPOINT inadyn --foreground ${INADYN_OPTS}


### PR DESCRIPTION
Can be validated using my docker image on docker hub: https://hub.docker.com/repository/docker/dprus/inadyn

Most importantly this allows me to easily specify "-l debug" when I need to.