### PR TITLE
Fix string copy length issue in cloudflare provider

### DIFF
--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -199,10 +199,14 @@ static int json_copy_value(char *dest, size_t dest_size, const char *json, const
 		return -1;
 	
 	length = token->end - token->start;
+	logit(LOG_INFO, "token->start: %i", token->start);
+	logit(LOG_INFO, "token->end: %i", token->end);
+	logit(LOG_INFO, "length: %i", length);
+	logit(LOG_INFO, "dest_size: %i", dest_size);
 	if (length >= dest_size)
 		return -2;
 	
-	strlcpy(dest, json + token->start, length);
+	strlcpy(dest, json + token->start, length+1);
 
 	return 0;
 }
@@ -248,11 +252,13 @@ static int get_id(char *dest, size_t dest_size, const ddns_info_t *info, char *r
 		rc = RC_DDNS_RSP_NOHOST;
 		goto cleanup;
 	}
+  logit(LOG_DEBUG, "ID position in string: %i", id);
 
 	if (json_copy_value(dest, dest_size, body, &id) < 0) {
 		logit(LOG_ERR, "Id did not fit into buffer.");
 		rc = RC_BUFFER_OVERFLOW;
 	}
+  logit(LOG_DEBUG, "ID value: %s", dest);
 
 cleanup:
 	free(response_buf);


### PR DESCRIPTION
The debugging here is a bit excessive but it shows the problem:

```
{"result":[{"id":"aad8dfa1218ae29dbdfe5fa9569cb682","name":"netconsonance.com","....snip
Jan 14 00:39:32  inadyn[64113] <Debug>: ID position in string: 3
Jan 14 00:39:32  inadyn[64113] <Info>: token->start: 18
Jan 14 00:39:32  inadyn[64113] <Info>: token->end: 50
Jan 14 00:39:32  inadyn[64113] <Info>: length: 32
Jan 14 00:39:32  inadyn[64113] <Debug>: ID value: aad8dfa1218ae29dbdfe5fa9569cb68
Jan 14 00:39:32  inadyn[64113] <Debug>: Cloudflare Zone: 'netconsonance.com' Id: aad8dfa1218ae29dbdfe5fa9569cb68
```

If you add one to the length calculation it trips over the dest_size limit, so the only fix is to add one to the length when calling `strlcpy()`

```
{"result":[{"id":"aad8dfa1218ae29dbdfe5fa9569cb682","name":"netconsonance.com","....snip
Jan 14 00:42:26  inadyn[64747] <Debug>: ID position in string: 3
Jan 14 00:42:26  inadyn[64747] <Info>: token->start: 18
Jan 14 00:42:26  inadyn[64747] <Info>: token->end: 50
Jan 14 00:42:26  inadyn[64747] <Info>: length: 32
Jan 14 00:42:26  inadyn[64747] <Info>: dest_size: 33
Jan 14 00:42:26  inadyn[64747] <Debug>: ID value: aad8dfa1218ae29dbdfe5fa9569cb682
```