### PR TITLE
Concert Cloudflare to use new ddns_info_t:data field in setup() and request()

### DIFF
--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -306,7 +306,10 @@ static int setup(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *hostname)
 	if (!data)
 		return RC_OUT_OF_MEMORY;
 
+	if (info->data)
+		free(info->data);
 	info->data = data;
+
 	get_zone(zone_name, sizeof(zone_name), hostname->name);
 	record_type = get_record_type(hostname->address);
 


### PR DESCRIPTION
The patch converts the Cloudflare plugin to use a new 'data' field, reserved for plugins, in the setup() and request() callbacks.  This way we can have one Inadyn instance serve multiple Cloudflare accounts, i.e., no more global variables.