### PR TITLE
Add common authentication failure error code

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -54,6 +54,7 @@
 #define RC_DDNS_RSP_NOHOST              47
 #define RC_DDNS_RSP_NOTOK               48
 #define RC_DDNS_RSP_RETRY_LATER         49
+#define RC_DDNS_RSP_AUTH_FAIL           50
 
 #define RC_OS_INVALID_IP_ADDRESS        61
 #define RC_OS_FORK_FAILURE              62

--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -108,7 +108,7 @@ static int check_response_code(int status)
 		return RC_DDNS_RSP_NOTOK;
 	case 403:
 		logit(LOG_ERR, "HTTP 403: Provided API token does not have the required permissions.");
-		return RC_DDNS_INVALID_OPTION;
+		return RC_DDNS_RSP_AUTH_FAIL;
 	case 429:
 		logit(LOG_WARNING, "HTTP 429: We got rate limited.");
 		return RC_DDNS_RSP_RETRY_LATER;

--- a/plugins/common.c
+++ b/plugins/common.c
@@ -79,6 +79,9 @@ int common_response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
 	if (strstr(body, "dnserr") || strstr(body, "911"))
 		return RC_DDNS_RSP_RETRY_LATER;
 
+	if (strstr(body, "badauth"))
+		return RC_DDNS_RSP_AUTH_FAIL;
+
 	/* Loopia responds "[200 OK] nohost" when no DNS record exists */
 	if (strstr(body, "nohost"))
 		return RC_DDNS_RSP_NOHOST;

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -671,7 +671,7 @@ static int update_alias_table(ddns_t *ctx)
 				os_shell_execute(script_exec, alias->address, alias->name);
 		}
 
-		if (RC_DDNS_RSP_NOTOK == rc)
+		if (RC_DDNS_RSP_NOTOK == rc || RC_DDNS_RSP_AUTH_FAIL == rc)
 			remember = rc;
 
 		if (RC_DDNS_RSP_RETRY_LATER == rc && !remember)
@@ -838,6 +838,7 @@ static int check_error(ddns_t *ctx, int rc)
 		break;
 
 	case RC_DDNS_RSP_NOTOK:
+	case RC_DDNS_RSP_AUTH_FAIL:
 		if (ignore_errors) {
 			logit(LOG_WARNING, "%s, ignoring ...", errstr);
 			break;

--- a/src/error.c
+++ b/src/error.c
@@ -59,6 +59,7 @@ static const ERROR_NAME global_error_table[] = {
 	{ RC_DDNS_INVALID_OPTION,         "Invalid or missing DDNS option"   },
 	{ RC_DDNS_RSP_NOTOK,              "DDNS server response not OK"      },
 	{ RC_DDNS_RSP_RETRY_LATER,        "DDNS server busy, try later"      },
+	{ RC_DDNS_RSP_AUTH_FAIL,          "Authentication failure"           },
 
 	{ RC_OS_FORK_FAILURE,             "Failed forking off child"         },
 	{ RC_OS_CHANGE_PERSONA_FAILURE,   "Failed dropping privileges"       },

--- a/src/http.c
+++ b/src/http.c
@@ -146,6 +146,9 @@ int http_status_valid(int status)
 	if (status == 200)
 		return 0;
 
+	if (status == 401 || status == 403)
+		return RC_DDNS_RSP_AUTH_FAIL;
+
 	if (status >= 500 && status < 600)
 		return RC_DDNS_RSP_RETRY_LATER;
 


### PR DESCRIPTION
Useful for human-readable logging and can be used for additional logic of custom plugins/further script actions.
For example it's currently used for asuscomm.com in https://github.com/RMerl/asuswrt-merlin.ng