### PR TITLE
Improvements for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,23 +5,24 @@ RUN apk --no-cache add --virtual .build-dependencies \
   automake \
   confuse-dev \
   gcc \
-  git \
   gnutls-dev \
   libc-dev \
   libtool \
   make
 
-RUN git clone https://github.com/troglobit/inadyn.git
-WORKDIR inadyn
+WORKDIR /root
+COPY . ./
 RUN ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var && make install
 
-RUN apk del .build-dependencies
+
+FROM alpine:latest
 
 RUN apk --no-cache add \
   ca-certificates \
   confuse \
   gnutls
 
+COPY --from=0 /usr/sbin/inadyn /usr/sbin/inadyn
+COPY --from=0 /usr/share/doc/inadyn /usr/share/doc/inadyn
 ENV INADYN_OPTS=""
-
 ENTRYPOINT inadyn --foreground ${INADYN_OPTS}


### PR DESCRIPTION
Hi @troglobit . Thank you for the inadyn project. I find it very usefull!

I have two suggestions to improve the Dockerfile of your project.
- Instead of calling git in Dockerfile, use COPY to take all the files from the actual commit and use these files to build inadyn. In the future, it will allow to checkout to a tag version (v2.6 for example) and recreate a Docker image with version 2.6 of the code. Actually, if I take any commit that contains the Dockerfile and I build the image, it always build the latest commit of master.
- Use another alpine build stage to copy only the result of the build in the final Docker image. It will create a slightly smaller image as the sources will not be in a layer of the final image.

I take only the executable and doc folder from the build result. I think it is everything that is needed, but don't hesitate to tell me if it is missing something.