### PR TITLE
Always run exec handler

### DIFF
--- a/include/ddns.h
+++ b/include/ddns.h
@@ -90,6 +90,11 @@ typedef enum {
 	CMD_CHECK_NOW,
 } ddns_cmd_t;
 
+typedef enum {
+	EXEC_MODE_COMPAT,
+	EXEC_MODE_EVENT
+} ddns_exec_mode_t;
+
 typedef struct {
 	char           username[USERNAME_LEN];
 	char           password[PASSWORD_LEN];
@@ -198,6 +203,7 @@ extern int ignore_errors;
 extern int startup_delay;
 extern int allow_ipv6;
 extern int verify_addr;
+extern int exec_mode;
 extern char *ident;
 extern char *prognm;
 extern char *iface;

--- a/include/os.h
+++ b/include/os.h
@@ -60,7 +60,7 @@
 
 int os_install_signal_handler (void *ctx);
 int os_check_perms            (void);
-int os_shell_execute          (char *cmd, char *ip, char *hostname);
+int os_shell_execute          (char *cmd, char *ip, char *hostname, char *event, int error);
 
 #endif /* INADYN_OS_H_ */
 

--- a/man/inadyn.8
+++ b/man/inadyn.8
@@ -23,6 +23,7 @@
 .Op Fl c, -cmd Ar /path/to/cmd
 .Op Fl C, -continue-on-error
 .Op Fl e, -exec Ar /path/to/cmd
+.Op Fl -exec-mode Ar MODE
 .Op Fl f, -config Ar FILE
 .Op Fl h, -help
 .Op Fl i, -iface Ar IFNAME
@@ -193,19 +194,33 @@ to not exit on errors from a DDNS provider and instead try again later.
 Please do not use this, it usually indicates that we are sending a
 malformed request, e.g. wrong username, password or DNS alias for the
 given account.  Continuing could possibly lock you out of your account!
-.It Fl e, -exec Ar /path/to/cmd Op optional args
-Full path to command, or script, to run after a successful DDNS update.
+.It Fl e, -exec=/path/to/cmd Op optional args
+Full path to command, or script, to run.
 The following environment variables are set: INADYN_IP, INADYN_HOSTNAME.
 The first environment variable contains the new IP address, the second
 the host name alias.  The
 .Nm cmd
-is called for each listed host name that is successfully updated.  If
+is called for each listed host name.  If
 .Nm
 is started with the
 .Fl i Ar IFNAME
 command line option, the INADYN_IFACE environment variable is also set.
 You will need to quote the complete command if any arguments, or pipe,
 is given.
+.It Fl -exec-mode Ar MODE
+Use
+.Ar MODE
+to set the exec script run mode: compat, event:
+- compat: run exec handler on successful DDNS update only, default
+- event: run exec handler on any update status
+The following environment variables are set:
+INADYN_EVENT, INADYN_ERROR, INADYN_ERROR_MESSAGE.
+INADYN_EVENT contains the event, one of: nochg, update, error.
+The event nochg indicates that no update had to be sent, the event
+update indicates that an update was sent successully, the event error
+indicates that the update was sent and an error occurred.
+INADYN_ERROR contains the error code,
+INADYN_ERROR_MESSAGE contains the error message for the error code.
 .It Fl f, -config Ar FILE
 Use
 .Ar FILE

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@ char  *config = NULL;
 char  *cache_dir = NULL;
 char  *script_cmd = NULL;
 char  *script_exec = NULL;
+int exec_mode = EXEC_MODE_COMPAT;
 char  *pidfile_name = NULL;
 uid_t  uid = 0;
 gid_t  gid = 0;
@@ -269,7 +270,10 @@ static int usage(int code)
 		"                                Default use ident NAME: %s/\n"
 		" -c, --cmd=/path/to/cmd         Script or command to run to check IP\n"
 		" -C, --continue-on-error        Ignore errors from DDNS provider\n"
-		" -e, --exec=/path/to/cmd        Script to run on successful DDNS update\n"
+		" -e, --exec=/path/to/cmd        Script to run on DDNS update\n"
+		"     --exec-mode=MODE           Set script run mode: compat, event:\n"
+		"                                - compat: successful DDNS update only, default\n"
+		"                                - event: any update status\n"
 		"     --check-config             Verify syntax of configuration file and exit\n"
 		" -f, --config=FILE              Use FILE name for configuration, default uses\n"
 		"                                ident NAME: %s\n"
@@ -323,6 +327,7 @@ int main(int argc, char *argv[])
 		{ "cmd",               1, 0, 'c' },
 		{ "continue-on-error", 0, 0, 'C' },
 		{ "exec",              1, 0, 'e' },
+		{ "exec-mode",         1, 0, 130 },
 		{ "config",            1, 0, 'f' },
 		{ "check-config",      0, 0, 129 },
 		{ "iface",             1, 0, 'i' },
@@ -368,6 +373,15 @@ int main(int argc, char *argv[])
 
 		case 'e':	/* --exec=CMD */
 			script_exec = optarg;
+			break;
+
+		case 130:	/* --exec-mode=MODE */
+			if (!strcmp(optarg, "event"))
+				exec_mode = EXEC_MODE_EVENT;
+			else if (!strcmp(optarg, "compat"))
+				exec_mode = EXEC_MODE_COMPAT;
+			else
+				return usage(1);
 			break;
 
 		case 'f':	/* --config=FILE */

--- a/src/os.c
+++ b/src/os.c
@@ -38,6 +38,8 @@ static void *param = NULL;
  * @cmd:  Full path to script or command to run
  * @ip:   IP address to set as %INADYN_IP env. variable
  * @name: String to set as %INADYN_HOSTNAME env. variable
+ * @event:Event name to set as %INADYN_EVENT env. variable
+ * @error:Error code to set as %INADYN_ERROR env. variable
  *
  * If inadyn has been started with the --iface=IFNAME command line
  * option the IFNAME is sent to the script as %INADYN_IFACE.
@@ -45,18 +47,24 @@ static void *param = NULL;
  * Returns:
  * Posix %OK(0), or %RC_OS_FORK_FAILURE on vfork() failure
  */
-int os_shell_execute(char *cmd, char *ip, char *name)
+int os_shell_execute(char *cmd, char *ip, char *name, char *event, int error)
 {
 	int rc = 0;
 	int child;
+	char errbuf[11];
 
 	child = vfork();
 	switch (child) {
 	case 0:
+		snprintf(errbuf, sizeof(errbuf), "%d", error);
 		setenv("INADYN_IP", ip, 1);
 		setenv("INADYN_HOSTNAME", name, 1);
+		setenv("INADYN_EVENT", event, 1);
+		setenv("INADYN_ERROR", errbuf, 1);
+		setenv("INADYN_ERROR_MESSAGE", error_str(error), 1);
 		if (iface)
 			setenv("INADYN_IFACE", iface, 1);
+
 		execl("/bin/sh", "sh", "-c", cmd, (char *)0);
 		exit(1);
 		break;


### PR DESCRIPTION
Hi,
this pull request always runs the exec handler.

The option `--exec-mode=[compat|event]` is introduced. When set to event the script foo, in `--exec foo`, would be called with `$1` set to one of: `update`, `nochg`, `error`. `$2` provides the return code of the send update and `$3` the corresponding error message.

When `--exec-mode` is not set or set to `compat` the script foo would be called as-is today.