### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ sudo: false
 compiler:
   - gcc
   - clang
+arch:
+  - amd64
+  - ppc64le
 
 env:
   global:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/inadyn/builds/190327159 . I believe it is ready for the final review and merge.
Please have a look on this.

Thanks !!