### PR TITLE
docs: fix simple typo, unnnecessary -> unnecessary

### DIFF
--- a/src/ddns.c
+++ b/src/ddns.c
@@ -516,7 +516,7 @@ static int check_alias_update_table(ddns_t *ctx)
 			ddns_alias_t *alias = &info->alias[i];
 
 /* XXX: TODO time_to_check() will return false positive if the cache
- *     file is missing => causing unnnecessary update.  We should save
+ *     file is missing => causing unnecessary update.  We should save
  *     the cache file with the current IP instead and fall back to
  *     standard update interval!
  */


### PR DESCRIPTION
There is a small typo in src/ddns.c.

Should read `unnecessary` rather than `unnnecessary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md