### PR TITLE
Use github action to build multi-arch docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: troglobit/inadyn:latest
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le


### PR DESCRIPTION
This PR uses GitHub Actions to build multi-arch docker image and push to docker hub.

Steps to merge this PR:

1. Go to https://hub.docker.com/repository/docker/troglobit/inadyn/builds and disable automatic build.
2. Go to https://github.com/troglobit/inadyn/settings/hooks and remove docker hub webhook.
3. Go to https://hub.docker.com/settings/security and create a new access token.
4. Go to https://github.com/troglobit/inadyn/settings/secrets/actions and add two secrets.
    - DOCKERHUB_USERNAME
    - DOCKERHUB_TOKEN
5. Merge this PR.

Fixes #315.