### PR TITLE
Update docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,4 @@ RUN apk --no-cache add \
 
 COPY --from=0 /usr/sbin/inadyn /usr/sbin/inadyn
 COPY --from=0 /usr/share/doc/inadyn /usr/share/doc/inadyn
-ENV INADYN_OPTS=""
-ENTRYPOINT inadyn --foreground ${INADYN_OPTS}
+ENTRYPOINT ["/usr/sbin/inadyn", "--foreground"]


### PR DESCRIPTION
This PR uses a more idiomatic way to handle command line arguments for container entrypoint.

Currently: `docker run --env "INADYN_OPTS=--help" troglobit/inadyn`
With this PR: `docker run troglobit/inadyn --help`

Another small change is that it will be only one running process (inadyn) instead of two (sh + inadyn).