### PR TITLE
Run container with --no-pidfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN apk --no-cache add \
 
 COPY --from=0 /usr/sbin/inadyn /usr/sbin/inadyn
 COPY --from=0 /usr/share/doc/inadyn /usr/share/doc/inadyn
-ENTRYPOINT ["/usr/sbin/inadyn", "--foreground"]
+ENTRYPOINT ["/usr/sbin/inadyn", "--foreground", "--no-pidfile"]


### PR DESCRIPTION
This is not a fix, but would address #334 in container use case before we have a proper fix.