### PR TITLE
Add missing provider option definitions to custom section options (fixes #340)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -557,6 +557,8 @@ cfg_t *conf_parse_file(char *file, ddns_t *ctx)
 		CFG_STR_LIST("alias",        NULL, CFGF_DEPRECATED),
 		CFG_BOOL    ("ssl",          cfg_true, CFGF_NONE),
 		CFG_BOOL    ("wildcard",     cfg_false, CFGF_NONE),
+		CFG_INT     ("ttl",          -1, CFGF_NODEFAULT),
+		CFG_BOOL    ("proxied",      cfg_false, CFGF_NONE),
 		CFG_STR     ("checkip-server", NULL, CFGF_NONE), /* Syntax:  name:port */
 		CFG_STR     ("checkip-path",   NULL, CFGF_NONE), /* Default: "/" */
 		CFG_BOOL    ("checkip-ssl",    cfg_true, CFGF_NONE),


### PR DESCRIPTION
I'm not sure if this is the best solution, but from the existing code comment I assume that all options available in a provider configuration section should also apply to a custom section.  The `ttl` and `proxied` options were added recently and are not present in the custom options descriptor array.

So copying these two lines from above fixes the messages reported in #340 and makes inadyn work for me without complaints.