### PR TITLE
Use the OpenSSL or GnuTLS hash functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,10 @@ if test "x$ac_enable_ssl" = "xyes"; then
       CPPFLAGS="$CPPFLAGS $GnuTLS_CFLAGS"
       AC_CHECK_LIB([gnutls], [gnutls_init], [],
                           AC_MSG_ERROR([*** SSL library (GnuTLS) not found!]))
+      dnl GnuTLS uses nettle, so this doesn't really add a new dependency. It must
+      dnl be made explicit to avoid underlinking.
+      AC_CHECK_LIB([nettle], [nettle_md5_init], [],
+                          AC_MSG_ERROR([*** Crypto library (nettle) not found!]))
       AC_CHECK_HEADERS([gnutls/gnutls.h gnutls/x509.h], [],
 			  AC_MSG_ERROR([*** Cannot find required header files!]))
       AC_DEFINE([CONFIG_GNUTLS], [], [Enable HTTPS support using GnuTLS library])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,21 +8,20 @@ sbin_PROGRAMS	 = inadyn
 inadyn_SOURCES	 = main.c	ddns.c		cache.c		\
 		   error.c	conf.c		os.c		\
 		   http.c	plugin.c	tcp.c		\
-		   sha1.c	\
 		   json.c	jsmn.c		log.c		\
-		   makepath.c	md5.c
+		   makepath.c
 inadyn_CFLAGS    = $(confuse_CFLAGS) $(OpenSSL_CFLAGS) $(GnuTLS_CFLAGS)
 inadyn_LDADD     = $(confuse_LIBS)   $(OpenSSL_LIBS)   $(GnuTLS_LIBS)
 inadyn_LDADD    += $(LIBS) $(LIBOBJS)
 
 if ENABLE_SSL
 if ENABLE_OPENSSL
-inadyn_SOURCES  += openssl.c openssl_base64.c
+inadyn_SOURCES  += openssl.c openssl_base64.c openssl_hash.c
 else
-inadyn_SOURCES  += gnutls.c gnutls_base64.c
+inadyn_SOURCES  += gnutls.c gnutls_base64.c gnutls_hash.c
 endif
 else
-inadyn_SOURCES  += base64.c
+inadyn_SOURCES  += base64.c md5.c sha1.c
 endif
 
 ## Plugins are currently built-in, and built from this directory instead

--- a/src/gnutls_hash.c
+++ b/src/gnutls_hash.c
@@ -1,0 +1,45 @@
+/* Nettle interface for hash functions
+ *
+ * Copyright (C) 2021  Dan Fandrich <dan@coneharvesters.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, visit the Free Software Foundation
+ * website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "md5.h"
+#include "sha1.h"
+#include <nettle/md5.h>
+#include <nettle/sha.h>
+
+/* Calculate the MD5 hash checksum of the given input */
+void md5(const unsigned char *input, size_t ilen, unsigned char output[16])
+{
+	struct md5_ctx ctx;
+
+	md5_init(&ctx);
+	md5_update(&ctx, ilen, input);
+	md5_digest(&ctx, MD5_DIGEST_SIZE, output);
+}
+
+/* Calculate the SHA-1 hash checksum of the given input */
+void sha1(const unsigned char *input, size_t ilen, unsigned char output[20])
+{
+	struct sha1_ctx ctx;
+
+	sha1_init(&ctx);
+	sha1_update(&ctx, ilen, input);
+	sha1_digest(&ctx, SHA1_DIGEST_SIZE, output);
+}

--- a/src/openssl_hash.c
+++ b/src/openssl_hash.c
@@ -1,0 +1,45 @@
+/* OpenSSL interface for hash functions
+ *
+ * Copyright (C) 2021  Dan Fandrich <dan@coneharvesters.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, visit the Free Software Foundation
+ * website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "md5.h"
+#include "sha1.h"
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+
+/* Calculate the MD5 hash checksum of the given input */
+void md5(const unsigned char *input, size_t ilen, unsigned char output[16])
+{
+	MD5_CTX ctx;
+
+	MD5_Init(&ctx);
+	MD5_Update(&ctx, input, ilen);
+	MD5_Final(output, &ctx);
+}
+
+/* Calculate the SHA-1 hash checksum of the given input */
+void sha1(const unsigned char *input, size_t ilen, unsigned char output[20])
+{
+	SHA_CTX ctx;
+
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, input, ilen);
+	SHA1_Final(output, &ctx);
+}


### PR DESCRIPTION
These are generally better optimized than the generic versions bundled
with inadyn, and significantly reduce the size of the final binary.