### PR TITLE
Use the OpenSSL or GnuTLS base64 functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ sbin_PROGRAMS	 = inadyn
 inadyn_SOURCES	 = main.c	ddns.c		cache.c		\
 		   error.c	conf.c		os.c		\
 		   http.c	plugin.c	tcp.c		\
-		   		sha1.c		base64.c	\
+		   sha1.c	\
 		   json.c	jsmn.c		log.c		\
 		   makepath.c	md5.c
 inadyn_CFLAGS    = $(confuse_CFLAGS) $(OpenSSL_CFLAGS) $(GnuTLS_CFLAGS)
@@ -17,10 +17,12 @@ inadyn_LDADD    += $(LIBS) $(LIBOBJS)
 
 if ENABLE_SSL
 if ENABLE_OPENSSL
-inadyn_SOURCES  += openssl.c
+inadyn_SOURCES  += openssl.c openssl_base64.c
 else
-inadyn_SOURCES  += gnutls.c
+inadyn_SOURCES  += gnutls.c gnutls_base64.c
 endif
+else
+inadyn_SOURCES  += base64.c
 endif
 
 ## Plugins are currently built-in, and built from this directory instead

--- a/src/gnutls_base64.c
+++ b/src/gnutls_base64.c
@@ -1,0 +1,78 @@
+/* base64 encoding/decoding functions for GnuTLS
+*
+* Copyright (C) 2021  Dan Fandrich <dan@coneharvesters.com>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, visit the Free Software Foundation
+* website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301, USA.
+*/
+
+#include "base64.h"
+#include <gnutls/gnutls.h>
+
+/*
+ * Encode a buffer into base64 format
+ */
+int base64_encode(unsigned char *dst, size_t *dlen, const unsigned char *src, size_t slen)
+{
+	gnutls_datum_t in = {(unsigned char *)src, slen}, out;
+
+	int rc = gnutls_base64_encode2(&in, &out);
+	if (rc != GNUTLS_E_SUCCESS) {
+		/* This is probably an OOM error, so try to return something semi-sane */
+		*dlen = slen * 2 + 1;
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+	if ((out.size + 1) > *dlen) {
+		*dlen = out.size + 1;
+		gnutls_free(out.data);
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+	memcpy(dst, out.data, out.size);
+	dst[out.size] = 0;
+	*dlen = out.size;
+
+	gnutls_free(out.data);
+
+	return 0;
+}
+
+/*
+ * Decode a base64-formatted buffer
+ */
+int base64_decode(unsigned char *dst, size_t *dlen, const unsigned char *src, size_t slen)
+{
+	gnutls_datum_t in = {(unsigned char *)src, slen}, out;
+
+	int rc = gnutls_base64_decode2(&in, &out);
+	if (rc == GNUTLS_E_BASE64_DECODING_ERROR)
+		return ERR_BASE64_INVALID_CHARACTER;
+	if (rc != GNUTLS_E_SUCCESS) {
+		/* This is probably an OOM error, so try to return something semi-sane */
+		*dlen = slen;
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+	if (out.size > *dlen) {
+		*dlen = out.size;
+		gnutls_free(out.data);
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+	memcpy(dst, out.data, out.size);
+	*dlen = out.size;
+
+	gnutls_free(out.data);
+
+	return 0;
+}

--- a/src/openssl_base64.c
+++ b/src/openssl_base64.c
@@ -1,0 +1,61 @@
+/* base64 encoding/decoding functions for OpenSSL
+*
+* Copyright (C) 2021  Dan Fandrich <dan@coneharvesters.com>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, visit the Free Software Foundation
+* website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301, USA.
+*/
+
+#include "base64.h"
+#include <openssl/evp.h>
+
+/*
+ * Encode a buffer into base64 format
+ */
+int base64_encode(unsigned char *dst, size_t *dlen, const unsigned char *src, size_t slen)
+{
+	size_t needed = (((4 * slen / 3) + 3) & ~3) + 1;  // +1 for NUL
+
+	if (slen && (*dlen < needed)) {
+		*dlen = needed;
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+
+	*dlen = EVP_EncodeBlock(dst, src, slen);
+
+	return 0;
+}
+
+/*
+ * Decode a base64-formatted buffer
+ */
+int base64_decode(unsigned char *dst, size_t *dlen, const unsigned char *src, size_t slen)
+{
+	size_t needed = (3 * slen) / 4;
+	int rc;
+
+	if (*dlen < needed) {
+		*dlen = needed;
+		return ERR_BASE64_BUFFER_TOO_SMALL;
+	}
+
+	rc = EVP_DecodeBlock(dst, src, slen);
+	if (rc < 0)
+		return ERR_BASE64_INVALID_CHARACTER;
+	*dlen = (size_t) rc;
+
+	return 0;
+}


### PR DESCRIPTION
These should be better optimized than the generic versions bundled
with inadyn, and reduce the size of the final binary.