### PR TITLE
Add an option to build a smaller binary for embedded applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,13 @@ Check that it started properly by inspecting the system log, or:
 
     $ sudo systemctl status inadyn.service
 
+### Embedded applications
+
+When built into a router, some features aren't usually used and can be disabled
+to save space. The configure option `--enable-reduced` will build such a
+reduced-functionality binary. Currently, this disables verbose log messages and
+error strings and eliminates config file checking & some backward compatibility.
+
 
 Building from GIT
 -----------------

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,13 @@ AC_ARG_ENABLE(openssl,
         [ac_enable_openssl="no"]
 )
 
+AC_ARG_ENABLE(reduced,
+        [AS_HELP_STRING([--enable-reduced], [Drop some features to reduce the binary size, default: disabled])],
+        [ac_enable_reduced="$enableval"],
+        [ac_enable_reduced="no"]
+)
+
+
 AC_ARG_ENABLE(simulation,
         [AS_HELP_STRING([--enable-simulation], [Developer simulation mode, do not use!])],
         [ac_enable_simulation="$enableval"],
@@ -149,6 +156,10 @@ fi
 #   https://www.happyassassin.net/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/
 CAFILE1="/etc/ssl/certs/ca-certificates.crt"
 CAFILE2="/etc/pki/tls/certs/ca-bundle.trust.crt"
+
+if test "x$ac_enable_reduced" = "xyes"; then
+      CPPFLAGS="$CPPFLAGS -DMAX_LOG_LEVEL=LOG_ERR -DDROP_VERBOSE_STRINGS -DDROP_CHECK_CONFIG"
+fi
 
 # Add OS-specific flags
 case "$host_os" in

--- a/include/log.h
+++ b/include/log.h
@@ -25,13 +25,19 @@
 #include <stdarg.h>
 #include "os.h"
 
+#ifndef MAX_LOG_LEVEL
+#define MAX_LOG_LEVEL LOG_DEBUG
+#endif
+
 void log_init  (char *ident, int log, int bg);
 void log_exit  (void);
 
 int  log_level (char *level);
 
-void logit     (int prio, const char *fmt, ...);
+void logitf     (int prio, const char *fmt, ...);
 void vlogit    (int prio, const char *fmt, va_list args);
+
+#define logit(p, ...) do if ((p) <= MAX_LOG_LEVEL) logitf((p), __VA_ARGS__); while (0)
 
 #endif /* INADYN_LOG_H_ */
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -59,6 +59,7 @@ static void conf_errfunc(cfg_t *cfg, const char *format, va_list args)
 	vlogit(LOG_ERR, fmt, args);
 }
 
+#ifdef DROP_CHECK_CONFIG
 /*
  * Convert deprecated 'alias' setting to new 'hostname',
  * same functionality with new name.
@@ -189,6 +190,7 @@ static int validate_custom(cfg_t *cfg, cfg_opt_t *opt)
 
 	return validate_common(cfg, "custom", 1);
 }
+#endif
 
 /* server:port => server:80 if port is not given */
 static int getserver(const char *server, ddns_name_t *name)
@@ -602,10 +604,12 @@ cfg_t *conf_parse_file(char *file, ddns_t *ctx)
 	/* Custom logging, rather than default Confuse stderr logging */
 	cfg_set_error_function(cfg, conf_errfunc);
 
+#ifdef DROP_CHECK_CONFIG
 	/* Validators */
 	cfg_set_validate_func(cfg, "period", validate_period);
 	cfg_set_validate_func(cfg, "provider", validate_provider);
 	cfg_set_validate_func(cfg, "custom", validate_custom);
+#endif
 
 	switch (cfg_parse(cfg, file)) {
 	case CFG_FILE_ERROR:

--- a/src/error.c
+++ b/src/error.c
@@ -28,46 +28,52 @@ typedef struct {
 	const char *p_name;
 } ERROR_NAME;
 
+#ifndef DROP_VERBOSE_STRINGS
+#define E(a) a
+#else
+#define E(a) "Err"
+#endif
+
 static const ERROR_NAME global_error_table[] = {
-	{ RC_OK,                          "OK"                               },
-	{ RC_ERROR,                       "Error"                            },
-	{ RC_INVALID_POINTER,             "Invalid pointer"                  },
-	{ RC_OUT_OF_MEMORY,               "Out of memory"                    },
-	{ RC_BUFFER_OVERFLOW,             "Too small internal buffer"        },
-	{ RC_PIDFILE_EXISTS_ALREADY,      "Already running"                  },
+	{ RC_OK,                            "OK"                                },
+	{ RC_ERROR,                       E("Error"                            )},
+	{ RC_INVALID_POINTER,             E("Invalid pointer"                  )},
+	{ RC_OUT_OF_MEMORY,               E("Out of memory"                    )},
+	{ RC_BUFFER_OVERFLOW,             E("Too small internal buffer"        )},
+	{ RC_PIDFILE_EXISTS_ALREADY,      E("Already running"                  )},
 
-	{ RC_TCP_SOCKET_CREATE_ERROR,     "Failed creating IP socket"        },
-	{ RC_TCP_BAD_PARAMETER,           "Invalid Internet port"            },
-	{ RC_TCP_INVALID_REMOTE_ADDR,     "Temporary network error (DNS)"    },
-	{ RC_TCP_CONNECT_FAILED,          "Failed connecting to DDNS server" },
-	{ RC_TCP_SEND_ERROR,              "Temporary network error (send)"   },
-	{ RC_TCP_RECV_ERROR,              "Temporary network error (recv)"   },
+	{ RC_TCP_SOCKET_CREATE_ERROR,     E("Failed creating IP socket"        )},
+	{ RC_TCP_BAD_PARAMETER,           E("Invalid Internet port"            )},
+	{ RC_TCP_INVALID_REMOTE_ADDR,     E("Temporary network error (DNS)"    )},
+	{ RC_TCP_CONNECT_FAILED,          E("Failed connecting to DDNS server" )},
+	{ RC_TCP_SEND_ERROR,              E("Temporary network error (send)"   )},
+	{ RC_TCP_RECV_ERROR,              E("Temporary network error (recv)"   )},
 
-	{ RC_TCP_OBJECT_NOT_INITIALIZED,  "Internal error (TCP)"             },
-	{ RC_HTTP_OBJECT_NOT_INITIALIZED, "Internal error (HTTP)"            },
+	{ RC_TCP_OBJECT_NOT_INITIALIZED,  E("Internal error (TCP)"             )},
+	{ RC_HTTP_OBJECT_NOT_INITIALIZED, E("Internal error (HTTP)"            )},
 
-	{ RC_HTTPS_NO_TRUSTED_CA_STORE,   "System has no trusted CA store"             },
-	{ RC_HTTPS_OUT_OF_MEMORY,         "Out of memory (HTTPS)"                      },
-	{ RC_HTTPS_FAILED_CONNECT,        "Failed connecting to DDNS server (HTTPS)"   },
-	{ RC_HTTPS_FAILED_GETTING_CERT,   "Failed retrieving DDNS server cert (HTTPS)" },
-	{ RC_HTTPS_SEND_ERROR,            "Temporary network error (HTTPS send)"       },
-	{ RC_HTTPS_RECV_ERROR,            "Temporary network error (HTTPS recv)"       },
-	{ RC_HTTPS_SNI_ERROR,             "Failed setting HTTPS server name"           },
-	{ RC_HTTPS_INVALID_REQUEST,       "Invalid request (HTTPS)"                    },
+	{ RC_HTTPS_NO_TRUSTED_CA_STORE,   E("System has no trusted CA store"             )},
+	{ RC_HTTPS_OUT_OF_MEMORY,         E("Out of memory (HTTPS)"                      )},
+	{ RC_HTTPS_FAILED_CONNECT,        E("Failed connecting to DDNS server (HTTPS)"   )},
+	{ RC_HTTPS_FAILED_GETTING_CERT,   E("Failed retrieving DDNS server cert (HTTPS)" )},
+	{ RC_HTTPS_SEND_ERROR,            E("Temporary network error (HTTPS send)"       )},
+	{ RC_HTTPS_RECV_ERROR,            E("Temporary network error (HTTPS recv)"       )},
+	{ RC_HTTPS_SNI_ERROR,             E("Failed setting HTTPS server name"           )},
+	{ RC_HTTPS_INVALID_REQUEST,       E("Invalid request (HTTPS)"                    )},
 
-	{ RC_DDNS_INVALID_CHECKIP_RSP,    "Check IP server response not OK"  },
-	{ RC_DDNS_INVALID_OPTION,         "Invalid or missing DDNS option"   },
-	{ RC_DDNS_RSP_NOTOK,              "DDNS server response not OK"      },
-	{ RC_DDNS_RSP_RETRY_LATER,        "DDNS server busy, try later"      },
-	{ RC_DDNS_RSP_AUTH_FAIL,          "Authentication failure"           },
+	{ RC_DDNS_INVALID_CHECKIP_RSP,    E("Check IP server response not OK"  )},
+	{ RC_DDNS_INVALID_OPTION,         E("Invalid or missing DDNS option"   )},
+	{ RC_DDNS_RSP_NOTOK,              E("DDNS server response not OK"      )},
+	{ RC_DDNS_RSP_RETRY_LATER,        E("DDNS server busy, try later"      )},
+	{ RC_DDNS_RSP_AUTH_FAIL,          E("Authentication failure"           )},
 
-	{ RC_OS_FORK_FAILURE,             "Failed forking off child"         },
-	{ RC_OS_CHANGE_PERSONA_FAILURE,   "Failed dropping privileges"       },
-	{ RC_OS_INVALID_UID,              "Invalid or unknown UID"           },
-	{ RC_OS_INVALID_GID,              "Invalid or unknown GID"           },
+	{ RC_OS_FORK_FAILURE,             E("Failed forking off child"         )},
+	{ RC_OS_CHANGE_PERSONA_FAILURE,   E("Failed dropping privileges"       )},
+	{ RC_OS_INVALID_UID,              E("Invalid or unknown UID"           )},
+	{ RC_OS_INVALID_GID,              E("Invalid or unknown GID"           )},
 
-	{ RC_FILE_IO_ACCESS_ERROR,        "Failed create/modify file/dir"    },
-	{ RC_FILE_IO_MISSING_FILE,        "Missing .conf file"               },
+	{ RC_FILE_IO_ACCESS_ERROR,        E("Failed create/modify file/dir"    )},
+	{ RC_FILE_IO_MISSING_FILE,        E("Missing .conf file"               )},
 
 	{ RC_OK, NULL }
 };

--- a/src/log.c
+++ b/src/log.c
@@ -77,7 +77,7 @@ void vlogit(int prio, const char *fmt, va_list args)
 		vfprintf(stderr, fmt, args), fprintf(stderr, "\n");
 }
 
-void logit(int prio, const char *fmt, ...)
+void logitf(int prio, const char *fmt, ...)
 {
 	va_list args;
 

--- a/src/main.c
+++ b/src/main.c
@@ -263,7 +263,9 @@ static int usage(int code)
 	else
 		snprintf(pidfn, sizeof(pidfn), "%s", pidfile_name);
 
-	fprintf(stderr, "Usage:\n %s [1hnsv] [-c CMD] [-e CMD] [-f FILE] [-l LVL] [-p USR:GRP] [-t SEC]\n\n"
+	fprintf(stderr, "Usage:\n %s [-1hnsvC] [-c CMD] [-e CMD] [-f FILE] [-i IFNAME] [-I NAME] [-l LVL] [-p USR:GRP] [-P FILE] [-t SEC]"
+#ifndef DROP_VERBOSE_STRINGS
+        "\n\n"
 		" -1, --once                     Run only once, updates if too old or unknown\n"
 		"     --force                    Force update, even if address has not changed\n"
 		"     --cache-dir=PATH           Persistent cache dir of IP sent to providers.\n"
@@ -293,7 +295,12 @@ static int usage(int code)
 		"Bug report address: %s\n",
 		prognm, cache_dir, config,
 		prognm, prognm, pidfn,
-		PACKAGE_BUGREPORT);
+		PACKAGE_BUGREPORT
+#else
+		" --force --cache-dir=PATH --exec-mode=MODE --check-config --no-pidfile\n\n",
+		prognm
+#endif
+		);
 #ifdef PACKAGE_URL
 	fprintf(stderr, "Project homepage: %s\n", PACKAGE_URL);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -276,7 +276,9 @@ static int usage(int code)
 		"     --exec-mode=MODE           Set script run mode: compat, event:\n"
 		"                                - compat: successful DDNS update only, default\n"
 		"                                - event: any update status\n"
+#ifndef DROP_CHECK_CONFIG
 		"     --check-config             Verify syntax of configuration file and exit\n"
+#endif
 		" -f, --config=FILE              Use FILE name for configuration, default uses\n"
 		"                                ident NAME: %s\n"
 		" -h, --help                     Show summary of command line options and exit\n"
@@ -297,7 +299,11 @@ static int usage(int code)
 		prognm, prognm, pidfn,
 		PACKAGE_BUGREPORT
 #else
-		" --force --cache-dir=PATH --exec-mode=MODE --check-config --no-pidfile\n\n",
+		" --force --cache-dir=PATH --exec-mode=MODE"
+#ifndef DROP_CHECK_CONFIG
+		" --check-config"
+#endif
+		" --no-pidfile\n\n",
 		prognm
 #endif
 		);
@@ -325,7 +331,9 @@ int main(int argc, char *argv[])
 {
 	int c, restart, rc = 0;
 	int use_syslog = 1;
+#ifndef DROP_CHECK_CONFIG
 	int check_config = 0;
+#endif
 	int background = 1;
 	static const struct option opt[] = {
 		{ "once",              0, 0, '1' },
@@ -395,11 +403,13 @@ int main(int argc, char *argv[])
 			config = strdup(optarg);
 			break;
 
+#ifndef DROP_CHECK_CONFIG
 		case 129:	/* --check-config */
 			check_config = 1;
 			background = 0;
 			use_syslog--;
 			break;
+#endif
 
 		case 'i':	/* --iface=IFNAME */
 			use_iface = iface = optarg;
@@ -456,6 +466,7 @@ int main(int argc, char *argv[])
 	/* Figure out .conf file, cache directory, and PID file name */
 	DO(compose_paths());
 
+#ifndef DROP_CHECK_CONFIG
 	if (check_config) {
 		char pidfn[80];
 
@@ -489,6 +500,7 @@ int main(int argc, char *argv[])
 
 		return RC_OK;
 	}
+#endif
 
 	if (background) {
 		if (daemon(0, 0) < 0) {


### PR DESCRIPTION
Using the --enable-reduced configure option, a smaller binary is produced by
eliminating verbose log messages and error strings and eliminating config file
checking & some config backward compatibility.