### PR TITLE
add google domains example

### DIFF
--- a/examples/google-domains.conf
+++ b/examples/google-domains.conf
@@ -1,0 +1,9 @@
+# Inadyn v2.0 configuration file format
+period          = 300
+
+provider default@domains.google.com {
+    ssl         = true
+    username    = username
+    password    = password
+    hostname    = sub.domain.tld
+}


### PR DESCRIPTION
[Config in Google Domains Documentation](https://support.google.com/domains/answer/6147083?hl=en#zippy=%2Cset-up-a-client-program-on-your-gateway-host-or-server) is out of date. Requesting add config example since their documentation and support is atrocious. Tested and was able to connect with this config today.