### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -131,7 +131,9 @@ static int check_response_code(int status)
 
 static int check_success(const char *json, const jsmntok_t tokens[], const int num_tokens)
 {
-	for (int i = 1; i < num_tokens; i++) {
+	int i;
+
+	for (i = 1; i < num_tokens; i++) {
 		int set;
 
 		if (jsoneq(json, tokens + i, KEY_SUCCESS) != 0)
@@ -165,7 +167,7 @@ static int check_success_only(const char *json)
 static int get_result_value(const char *json, const char *key, jsmntok_t *out_result)
 {
 	jsmntok_t *tokens;
-	int num_tokens;
+	int i, num_tokens;
 	
 	num_tokens = parse_json(json, &tokens);
 	if (num_tokens < 0)
@@ -181,7 +183,7 @@ static int get_result_value(const char *json, const char *key, jsmntok_t *out_re
 		goto cleanup;
 	}
 	
-	for (int i = 1; i < num_tokens; i++) {
+	for (i = 1; i < num_tokens; i++) {
 		if (jsoneq(json, tokens + i, key) != 0)
 			continue;
 

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -189,8 +189,9 @@ static int is_address_valid(int family, const char *host)
 		"2606:4700:4700::64",
 		"2606:4700:4700::6400"
 	};
+	size_t i;
 
-	for (size_t i = 0; i < NELEMS(except); i++) {
+	for (i = 0; i < NELEMS(except); i++) {
 		if (!strncmp(host, except[i], strlen(host))) {
 			return 0;
 		}


### PR DESCRIPTION
Fix the following build failures raised since version 2.8 and https://github.com/troglobit/inadyn/commit/1928d7a80390a2ef651a32d5723531fca51384d4:

```
ddns.c: In function 'is_address_valid':
ddns.c:193:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (size_t i = 0; i < NELEMS(except); i++) {
  ^
```

Fixes:
 - http://autobuild.buildroot.org/results/9323cc7afceff75f7d41ff161b8d0ec9aefa164a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>