### PR TITLE
Use long version of commandline arguments for systemd service

### DIFF
--- a/inadyn.service.in
+++ b/inadyn.service.in
@@ -10,7 +10,7 @@ Requires=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=-@SYSCONFDIR@/default/inadyn
-ExecStart=@SBINDIR@/inadyn -n -s $INADYN_OPTS $INADYN_ARGS
+ExecStart=@SBINDIR@/inadyn --foreground --syslog $INADYN_OPTS $INADYN_ARGS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Generally this is considered good practice for scripts (more often read than written).