### PR TITLE
Feature/provider iface

### DIFF
--- a/include/ddns.h
+++ b/include/ddns.h
@@ -137,6 +137,9 @@ typedef struct di {
 	char           server_response[MAX_NUM_RESPONSES][MAX_RESPONSE_LEN];
 	size_t         server_response_num;
 
+	/* Interface for IP */
+	char           *ifname;
+
 	/* Address of "What's my IP" checker */
 	ddns_name_t    checkip_name;
 	char           checkip_url[SERVER_URL_LEN];

--- a/man/inadyn.conf.5
+++ b/man/inadyn.conf.5
@@ -166,6 +166,8 @@ record.  Default is to use HTTPS (true).
 The username, if applicable.  This might be referred to as hash by some providers.
 .It Cm password = PASSWORD
 The password, if applicable.
+.It Cm iface = IFNAME
+Same as the global setting, but only for this provider.  For more information, see above.
 .It Cm checkip-server = <default | checkip.example.com[:port]>
 This setting allows you to override the default checkip server with
 either the string

--- a/src/conf.c
+++ b/src/conf.c
@@ -354,6 +354,7 @@ static int set_provider_opts(cfg_t *cfg, ddns_info_t *info, int custom)
 	str = cfg_getstr(cfg, "password");
 	if (str && strlen(str) <= sizeof(info->creds.password))
 		strlcpy(info->creds.password, str, sizeof(info->creds.password));
+	info->ifname = cfg_getstr(cfg, "iface");
 
 	for (j = 0; j < cfg_size(cfg, "hostname"); j++) {
 		size_t pos = info->alias_count;
@@ -544,6 +545,7 @@ cfg_t *conf_parse_file(char *file, ddns_t *ctx)
 		CFG_BOOL    ("wildcard",     cfg_false, CFGF_NONE),
 		CFG_INT     ("ttl",          -1, CFGF_NODEFAULT),
 		CFG_BOOL    ("proxied",      cfg_false, CFGF_NONE),
+		CFG_STR     ("iface",          NULL, CFGF_NONE), /* interface name */
 		CFG_STR     ("checkip-server", NULL, CFGF_NONE), /* Syntax:  name:port */
 		CFG_STR     ("checkip-path",   NULL, CFGF_NONE), /* Default: "/" */
 		CFG_BOOL    ("checkip-ssl",    cfg_true, CFGF_NONE),

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -474,7 +474,7 @@ static int get_address_backend(ddns_t *ctx, ddns_info_t *info, char *address, si
 	if (!get_address_iface (ctx, info->ifname, address, len))
 		return 0;
 
-    /* Check the global interface */
+	/* Check the global interface */
 	if (!get_address_iface (ctx, iface, address, len))
 		return 0;
 

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -470,7 +470,12 @@ static int get_address_backend(ddns_t *ctx, ddns_info_t *info, char *address, si
 	if (!get_address_cmd   (ctx, info, address, len))
 		return 0;
 
-	if (!get_address_iface (ctx, iface,address, len))
+	/* Check info specific interface */
+	if (!get_address_iface (ctx, info->ifname, address, len))
+		return 0;
+
+    /* Check the global interface */
+	if (!get_address_iface (ctx, iface, address, len))
 		return 0;
 
 	if (!get_address_remote(ctx, info, address, len))


### PR DESCRIPTION
Update configuration to look for iface in provider sections and if present try that before trying the global iface configuration (other IP address source logic is unchanged) to determine the IP address for this provider.

This streamlines configuration of providers with multiple different IP sources when those sources are different interfaces. Previously, using multiple different interface sources required running multiple instances of inadyn. Now, a user only has to configure multiple providers to obtain the same end result.