### PR TITLE
readme.md: minor indenting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ This looks for the default `.conf` file, to check any file, use:
         username    = ian
         password    = secret
         hostname    = flemming.no-ip.com
-		user-agent  = inadyn/2.2
-	}
+        user-agent  = inadyn/2.2
+    }
 
     # With multiple usernames at the same provider, index with :#
     provider no-ip.com:2 {
         username       = james
         password       = bond
         hostname       = spectre.no-ip.com
-		checkip-ssl    = false
+        checkip-ssl    = false
         checkip-server = api.ipify.org
     }
 
@@ -186,6 +186,7 @@ This looks for the default `.conf` file, to check any file, use:
         username = your_username
         password = your_password
     }
+
     # Wildcard subdomains - notice the quotes (required!)
     provider domains.google.com:2 {
         hostname = "*.mydomain.com"
@@ -198,7 +199,7 @@ This looks for the default `.conf` file, to check any file, use:
         username    = futurekid
         password    = dreoadsad/+dsad21321    # update-key-in-advanced-tab
         hostname    = 1234534245321           # tunnel-id
-	}
+    }
 
     # dynv6.com update using a custom checkip-command, which works
     # if you have access to an Internet-connected interface.  Make
@@ -298,7 +299,7 @@ A custom DDNS provider can be setup like this:
         ddns-server    = update.example.com
         ddns-path      = "/update?hostname="
         hostname       = myhostname.example.net
-	}
+    }
 
 The following variables can be substituted into the configuration:
 
@@ -340,7 +341,7 @@ under an API section, or similar.
         ddns-server = members.dyndns.org
         ddns-path   = "/nic/update?hostname=%h.dyndns.org&myip=%i"
         hostname    = { YOURHOST, alias }
-	}
+    }
 
 Here a fully custom `ddns-path` with format specifiers are used, see the
 `inadyn.conf(5)` man page for details on this.


### PR DESCRIPTION
Hello there.

I'm a volunteer opensource contributor for various projects, mainly related to your project inadyn which we recently updated from our old inadyn 1.96ADV to inadyn 2.9.1 in DD-WRT as you may know its a 3rd party Firmware for many popular consumer routers.

We have simplified the user interface in some cases (providers) and fixed bugs on our side (not related to inadyn directly but our implementation) making sure it works and thus far all is coming along fine and obviously old inadyn configs are now incompatible and not an issue and was expected.

In any case we refer our users to your documentation on the setup side of thisngs and I noticed some of this alignment issues poked my eyes, so here in to unpoking them ;)