### PR TITLE
chore: add 'success' as a valid response by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Here a fully custom `ddns-path` with format specifiers are used, see the
 
 When using the generic plugin you should first inspect the response from
 the DDNS provider.  By default Inadyn looks for a `200 HTTP` response OK
-code and the strings `"good"`, `"OK"`, `"true"`, or `"updated"` in the
+code and the strings `"good"`, `"OK"`, `"true"`, `"success"`, or `"updated"` in the
 HTTP response body.  If the DDNS provider returns something else you can
 add a list of possible `ddns-response = { Arrr, kilroy }`, or just a
 single `ddns-response = Cool` -- if your provider does give any response

--- a/README.md
+++ b/README.md
@@ -346,6 +346,17 @@ under an API section, or similar.
 Here a fully custom `ddns-path` with format specifiers are used, see the
 `inadyn.conf(5)` man page for details on this.
 
+Another example:
+
+    # Custom configuration for dnsmadeeasy
+    custom dyn {
+        username    = DNSMADEEASYUSERNAME
+        password    = DNSMADEEASYPASSWORDFORTHISHOST
+        ddns-server = cp.dnsmadeeasy.com
+        ddns-path   = "/servlet/updateip?username=%u&password=%p&id=DNSMADEEASYHOSTID&ip=%i"
+        hostname    = HOST
+    }      
+
 When using the generic plugin you should first inspect the response from
 the DDNS provider.  By default Inadyn looks for a `200 HTTP` response OK
 code and the strings `"good"`, `"OK"`, `"true"`, `"success"`, or `"updated"` in the

--- a/plugins/generic.c
+++ b/plugins/generic.c
@@ -40,7 +40,7 @@
 	"User-Agent: %s\r\n\r\n"
 
 const char * const generic_responses[] =
-    { "OK", "good", "true", "updated", "nochg", NULL };
+    { "OK", "good", "true", "updated", "success", "nochg", NULL };
 
 static int request  (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
 static int response (http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);


### PR DESCRIPTION
This will automatically accept the responses for DNSMadeEasy DDNS service. 
It makes sense to have this word on the list of OK responses so inadyn accepts it out of the box with dnsmadeeasy or other providers.

Related-To: https://dnsmadeeasy.com/technology/dynamic-dns (bottom)