### PR TITLE
add new providers

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -8,4 +8,6 @@ inadyn_SOURCES += common.c	changeip.c	cloudflare.c	\
 		  yandex.c	zoneedit.c	goip.c		\
 		  desec.c	domaindiscount24.c	all-inkl.c \
 		  core-networks.c	dnsever.c	dnshome.c \
-		  dnsmadeeasy.c		dnsmax.c
+		  dnsmadeeasy.c		dnsmax.c	mydns.c \
+		  myonlineportal.c	namecheap.c	regfish.c \
+		  twodns.c

--- a/plugins/dyndns.c
+++ b/plugins/dyndns.c
@@ -399,30 +399,60 @@ static ddns_system_t udmedia = {
 	.server_url   = "/nic/update"
 };
 
-static ddns_system_t myonlineportal = {
-	.name         = "default@myonlineportal.net",
+static ddns_system_t dyndnsit = {
+	.name         = "default@dyndns.it",
 
 	.request      = (req_fn_t)request,
 	.response     = (rsp_fn_t)response,
 
-	.checkip_name = "ipv4.myonlineportal.net",
-	.checkip_url  = "/checkip",
+	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
+	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
-	.server_name  = "myonlineportal.net",
-	.server_url   = "/updateddns"
+	.server_name  = "update.dyndns.it",
+	.server_url   = "/nic/update"
 };
 
-static ddns_system_t myonlineportal_v6 = {
-	.name         = "ipv6@myonlineportal.net",
+static ddns_system_t infomaniak = {
+	.name         = "default@infomaniak.com",
 
 	.request      = (req_fn_t)request,
 	.response     = (rsp_fn_t)response,
 
-	.checkip_name = "ipv6.myonlineportal.net",
-	.checkip_url  = "/checkip",
+	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
+	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
-	.server_name  = "myonlineportal.net",
-	.server_url   = "/updateddns"
+	.server_name  = "infomaniak.com",
+	.server_url   = "/nic/update"
+};
+
+static ddns_system_t oray = {
+	.name         = "default@oray.com",
+
+	.request      = (req_fn_t)request,
+	.response     = (rsp_fn_t)response,
+
+	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
+	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+
+	.server_name  = "ddns.oray.com",
+	.server_url   = "/ph/update"
+};
+
+static ddns_system_t simply = {
+	.name         = "default@simply.com",
+
+	.request      = (req_fn_t)request,
+	.response     = (rsp_fn_t)response,
+
+	.checkip_name = DYNDNS_MY_IP_SERVER,
+	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
+	.checkip_ssl  = DYNDNS_MY_IP_SSL,
+
+	.server_name  = "api.simply.com",
+	.server_url   = "/2/ddns/"
 };
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
@@ -478,8 +508,12 @@ PLUGIN_INIT(plugin_init)
 	plugin_register_v6(&variomedia);
 	plugin_register(&udmedia);
 	plugin_register_v6(&udmedia);
-	plugin_register(&myonlineportal);
-	plugin_register(&myonlineportal_v6);
+	plugin_register(&dyndnsit);
+	plugin_register(&infomaniak);
+	plugin_register_v6(&infomaniak);
+	plugin_register(&oray);
+	plugin_register(&simply);
+	plugin_register_v6(&simply);
 }
 
 PLUGIN_EXIT(plugin_exit)
@@ -509,8 +543,10 @@ PLUGIN_EXIT(plugin_exit)
 	plugin_unregister(&schokokeks);
 	plugin_unregister(&variomedia);
 	plugin_unregister(&udmedia);
-	plugin_unregister(&myonlineportal);
-	plugin_unregister(&myonlineportal_v6);
+	plugin_unregister(&dyndnsit);
+	plugin_unregister(&infomaniak);
+	plugin_unregister(&oray);
+	plugin_unregister(&simply);
 }
 
 /**

--- a/plugins/namecheap.c
+++ b/plugins/namecheap.c
@@ -1,4 +1,4 @@
-/* Plugin for domaindiscount24.com
+/* Plugin for namecheap.com
  *
  * Copyright (C) 2023 Sebastian Gottschall <s.gottschall@dd-wrt.com>
  *
@@ -21,21 +21,22 @@
 
 #include "plugin.h"
 
-
-#define DDC24_UPDATE_IP_REQUEST						\
+#define NAMECHEAP_UPDATE_IP_REQUEST						\
 	"GET %s?"							\
-	"hostname=%s&"							\
+	"host=%s&"							\
 	"password=%s&"							\
+	"domain=%s&"							\
 	"ip=%s "							\
 	"HTTP/1.0\r\n"							\
 	"Host: %s\r\n"							\
 	"User-Agent: %s\r\n\r\n"
 
+
 static int request  (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
 static int response (http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);
 
-static ddns_system_t plugin_ddc24 = {
-	.name         = "default@domaindiscount24.com",
+static ddns_system_t plugin = {
+	.name         = "default@namecheap.com",
 
 	.request      = (req_fn_t)request,
 	.response     = (rsp_fn_t)response,
@@ -44,32 +45,19 @@ static ddns_system_t plugin_ddc24 = {
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
-	.server_name  = "dynamicdns.key-systems.net",
-	.server_url   =  "/update.php"
-};
-
-static ddns_system_t plugin_moniker = {
-	.name         = "default@moniker.com",
-
-	.request      = (req_fn_t)request,
-	.response     = (rsp_fn_t)response,
-
-	.checkip_name = DYNDNS_MY_IP_SERVER,
-	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
-	.checkip_ssl  = DYNDNS_MY_IP_SSL,
-
-	.server_name  = "dynamicdns.key-systems.net",
-	.server_url   =  "/update.php"
+	.server_name  = "dynamicdns.park-your-domain.com",
+	.server_url   = "/update"
 };
 
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 {
 	return snprintf(ctx->request_buf, ctx->request_buflen,
-		DDC24_UPDATE_IP_REQUEST,
+		NAMECHEAP_UPDATE_IP_REQUEST,
 		info->server_url,
-		alias->name,
+		info->creds.username,
 		info->creds.password,
+		alias->name,
 		alias->address,
 		info->server_name.name,
 		info->user_agent);
@@ -84,7 +72,7 @@ static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
 
 	DO(http_status_valid(trans->status));
 
-	if (strstr(rsp, "success"))
+	if (strstr(rsp, "good") || strstr(rsp, "nochg"))
 		return 0;
 
 	return RC_DDNS_RSP_NOTOK;
@@ -92,14 +80,12 @@ static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
 
 PLUGIN_INIT(plugin_init)
 {
-	plugin_register(&plugin_ddc24);
-	plugin_register(&plugin_moniker);
+	plugin_register(&plugin);
 }
 
 PLUGIN_EXIT(plugin_exit)
 {
-	plugin_unregister(&plugin_ddc24);
-	plugin_unregister(&plugin_moniker);
+	plugin_unregister(&plugin);
 }
 
 /**

--- a/plugins/regfish.c
+++ b/plugins/regfish.c
@@ -1,0 +1,116 @@
+/* Plugin for regfish.de
+ *
+ * Copyright (C) 2023 Sebastian Gottschall <s.gottschall@dd-wrt.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, visit the Free Software Foundation
+ * website at http://www.gnu.org/licenses/gpl-2.0.html or write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#include "plugin.h"
+
+#define REGFISH_UPDATE_IP_HTTP_REQUEST					\
+	"GET %s?"							\
+	"fqdn=%s&"							\
+	"forcehost=1&"							\
+	"authtype=secure&"						\
+	"token=%s&"							\
+	"ip=%s "   							\
+	"HTTP/1.0\r\n"							\
+	"Host: %s\r\n"							\
+	"User-Agent: %s\r\n\r\n"
+
+#define REGFISH_UPDATE_IP6_HTTP_REQUEST					\
+	"GET %s?"							\
+	"fqdn=%s&"							\
+	"forcehost=1&"							\
+	"authtype=secure&"						\
+	"token=%s&"							\
+	"ipv6=%s "   							\
+	"HTTP/1.0\r\n"							\
+	"Host: %s\r\n"							\
+	"User-Agent: %s\r\n\r\n"
+
+static int request (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
+static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);
+
+static ddns_system_t plugin = {
+	.name         = "default@regfish.de",
+
+	.request      = (req_fn_t)request,
+	.response     = (rsp_fn_t)response,
+
+	.checkip_name = "wtfismyip.com",
+	.checkip_url  = "/text",
+
+	.server_name  = "dyndns.regfish.de",
+	.server_url   = "/"
+};
+
+static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
+{
+	if (strstr(info->system->name, "ipv6")) {
+		return snprintf(ctx->request_buf, ctx->request_buflen,
+				REGFISH_UPDATE_IP6_HTTP_REQUEST,
+				info->server_url,
+				alias->name,
+				info->creds.username,
+				alias->address,
+				info->server_name.name,
+				info->user_agent);
+	} else {
+		return snprintf(ctx->request_buf, ctx->request_buflen,
+				REGFISH_UPDATE_IP_HTTP_REQUEST,
+				info->server_url,
+				alias->name,
+				info->creds.username,
+				alias->address,
+				info->server_name.name,
+				info->user_agent);
+	}
+}
+
+static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
+{
+	char *resp = trans->rsp_body;
+
+	(void)info;
+	(void)alias;
+
+	DO(http_status_valid(trans->status));
+
+	if (strstr(resp, "success") || strstr(resp, "100") || strstr(resp, "101"))
+		return RC_OK;
+
+	return RC_DDNS_RSP_NOTOK;
+}
+
+PLUGIN_INIT(plugin_init)
+{
+	plugin_register(&plugin);
+	plugin_register_v6(&plugin);
+}
+
+PLUGIN_EXIT(plugin_exit)
+{
+	plugin_unregister(&plugin);
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/plugins/twodns.c
+++ b/plugins/twodns.c
@@ -1,4 +1,4 @@
-/* Plugin for domaindiscount24.com
+/* Plugin for twodns.de
  *
  * Copyright (C) 2023 Sebastian Gottschall <s.gottschall@dd-wrt.com>
  *
@@ -21,21 +21,21 @@
 
 #include "plugin.h"
 
-
-#define DDC24_UPDATE_IP_REQUEST						\
+#define TWODNS_UPDATE_IP_REQUEST						\
 	"GET %s?"							\
 	"hostname=%s&"							\
-	"password=%s&"							\
 	"ip=%s "							\
 	"HTTP/1.0\r\n"							\
 	"Host: %s\r\n"							\
+	"Authorization: Basic %s\r\n"					\
 	"User-Agent: %s\r\n\r\n"
+
 
 static int request  (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
 static int response (http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);
 
-static ddns_system_t plugin_ddc24 = {
-	.name         = "default@domaindiscount24.com",
+static ddns_system_t plugin = {
+	.name         = "default@twodns.de",
 
 	.request      = (req_fn_t)request,
 	.response     = (rsp_fn_t)response,
@@ -44,32 +44,16 @@ static ddns_system_t plugin_ddc24 = {
 	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
-	.server_name  = "dynamicdns.key-systems.net",
-	.server_url   =  "/update.php"
+	.server_name  = "update.twodns.de",
+	.server_url   =  "/update"
 };
-
-static ddns_system_t plugin_moniker = {
-	.name         = "default@moniker.com",
-
-	.request      = (req_fn_t)request,
-	.response     = (rsp_fn_t)response,
-
-	.checkip_name = DYNDNS_MY_IP_SERVER,
-	.checkip_url  = DYNDNS_MY_CHECKIP_URL,
-	.checkip_ssl  = DYNDNS_MY_IP_SSL,
-
-	.server_name  = "dynamicdns.key-systems.net",
-	.server_url   =  "/update.php"
-};
-
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 {
 	return snprintf(ctx->request_buf, ctx->request_buflen,
-		DDC24_UPDATE_IP_REQUEST,
+		TWODNS_UPDATE_IP_REQUEST,
 		info->server_url,
 		alias->name,
-		info->creds.password,
 		alias->address,
 		info->server_name.name,
 		info->user_agent);
@@ -77,29 +61,22 @@ static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 
 static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
 {
-	char *rsp = trans->rsp_body;
-
 	(void)info;
 	(void)alias;
 
 	DO(http_status_valid(trans->status));
 
-	if (strstr(rsp, "success"))
-		return 0;
-
-	return RC_DDNS_RSP_NOTOK;
+	return 0;
 }
 
 PLUGIN_INIT(plugin_init)
 {
-	plugin_register(&plugin_ddc24);
-	plugin_register(&plugin_moniker);
+	plugin_register(&plugin);
 }
 
 PLUGIN_EXIT(plugin_exit)
 {
-	plugin_unregister(&plugin_ddc24);
-	plugin_unregister(&plugin_moniker);
+	plugin_unregister(&plugin);
 }
 
 /**

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,4 +46,6 @@ inadyn_SOURCES  += ../plugins/common.c		../plugins/changeip.c		\
 		   ../plugins/desec.c		../plugins/all-inkl.c \
 		   ../plugins/core-networks.c	../plugins/dnsever.c \
 		   ../plugins/dnshome.c		../plugins/dnsmadeeasy.c \
-		   ../plugins/dnsmax.c
+		   ../plugins/dnsmax.c		../plugins/mydns.c \
+		   ../plugins/myonlineportal.c	../plugins/namecheap.c \
+		   ../plugins/regfish.c		../plugins/twodns.c


### PR DESCRIPTION
once again:

changes: 
dnspod.cn ipv6 support, 
api change for myonlineportal.net (own plugin now)
new providers:
moniker.com
dyndns.it
infomaniak.com
oray.com
simply.com
mydns.jp
namecheap.com
regfish.de
twodns.de

Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>