### PR TITLE
RFC: enforce desired tcp operation mode (v4 or v6)

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -89,7 +89,7 @@ typedef struct {
 int http_construct          (http_t *client);
 int http_destruct           (http_t *client, int num);
 
-int http_init               (http_t *client, char *msg);
+int http_init               (http_t *client, char *msg, int force);
 int http_exit               (http_t *client);
 
 int http_transaction        (http_t *client, http_trans_t *trans);

--- a/include/ssl.h
+++ b/include/ssl.h
@@ -37,7 +37,7 @@ extern int broken_rtc;
 int     ssl_init(void);
 void    ssl_exit(void);
 
-int     ssl_open(http_t *client, char *msg);
+int     ssl_open(http_t *client, char *msg, int force);
 int     ssl_close(http_t *client);
 
 int     ssl_send(http_t *client, const char *buf, int     len);
@@ -47,7 +47,7 @@ int     ssl_recv(http_t *client,       char *buf, int buf_len, int *recv_len);
 #define ssl_init()  0
 #define ssl_exit()
 
-#define ssl_open(client, msg)                    tcp_init(&client->tcp, msg)
+#define ssl_open(client, msg, force)                    tcp_init(&client->tcp, msg, force)
 #define ssl_close(client)                        tcp_exit(&client->tcp)
 
 #define ssl_send(client, buf, len)               tcp_send(&client->tcp, buf, len)

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -30,6 +30,10 @@
 #define TCP_SOCKET_MAX_PORT		65535
 #define TCP_DEFAULT_READ_CHUNK_SIZE	100
 
+#define TCP_AUTO	0
+#define TCP_FORCE_IPV4	1
+#define TCP_FORCE_IPV6	2
+
 typedef enum {
 	NO_PROXY = 0,
 	PROXY_SOCKS4,
@@ -56,7 +60,7 @@ typedef struct {
 int tcp_construct          (tcp_sock_t *tcp);
 int tcp_destruct           (tcp_sock_t *tcp);
 
-int tcp_init               (tcp_sock_t *tcp, char *msg);
+int tcp_init               (tcp_sock_t *tcp, char *msg, int force);
 int tcp_exit               (tcp_sock_t *tcp);
 
 int tcp_send               (tcp_sock_t *tcp, const char *buf, int len);

--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -237,7 +237,7 @@ static int get_id(char *dest, size_t dest_size, const ddns_info_t *info, char *r
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	CHECK(http_init(&client, "Id query"));
+	CHECK(http_init(&client, "Id query",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4));
 
 	trans.req = request;
 	trans.req_len = request_len;

--- a/plugins/cloudxns.c
+++ b/plugins/cloudxns.c
@@ -160,7 +160,7 @@ static int http_send(struct http *http, char *msg, char *fmt, ...)
 	http_set_remote_name(&client, info->server_name.name);
 	client.ssl_enabled = info->ssl_enabled;
 
-	rc = http_init(&client, msg);
+	rc = http_init(&client, msg, TCP_AUTO);
 	if (rc)
 		goto err;
 

--- a/plugins/dnspod.c
+++ b/plugins/dnspod.c
@@ -96,7 +96,7 @@ static int fetch_record_id(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, 
 	http_set_remote_name(&client, info->server_name.name);
 	client.ssl_enabled = info->ssl_enabled;
 
-	rc = http_init(&client, "Sending record list query");
+	rc = http_init(&client, "Sending record list query",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
 	if (rc)
 		return -rc;
 

--- a/plugins/freedns.c
+++ b/plugins/freedns.c
@@ -69,7 +69,7 @@ static char *fetch_keys(ddns_t *ctx, ddns_info_t *info)
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	rc = http_init(&client, "Fetching account API key");
+	rc = http_init(&client, "Fetching account API key",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
 	if (rc)
 		return NULL;
 

--- a/plugins/yandex.c
+++ b/plugins/yandex.c
@@ -276,7 +276,7 @@ static int setup(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	rc = http_init(&client, "Sending records list query");
+	rc = http_init(&client, "Sending records list query", TCP_AUTO);
 	if (rc) {
 		http_destruct(&client, 1);
 		return rc;

--- a/src/cache.c
+++ b/src/cache.c
@@ -184,7 +184,10 @@ int write_cache_file(ddns_alias_t *alias, const char *name)
 	cache_file(alias->name, name, path, sizeof(path));
 	fp = fopen(path, "w");
 	if (fp) {
-		logit(LOG_NOTICE, "Updating cache for %s", alias->name);
+		if (strstr(name, "v6"))
+			logit(LOG_NOTICE, "Updating IPv6 cache for %s", alias->name);
+		else
+			logit(LOG_NOTICE, "Updating IPv4 cache for %s", alias->name);
 		fprintf(fp, "%s", alias->address);
 		fclose(fp);
 

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -136,7 +136,7 @@ static int server_transaction(ddns_t *ctx, ddns_info_t *provider)
 
 	client = &provider->checkip;
 	client->ssl_enabled = provider->checkip_ssl;
-	DO(http_init(client, "Checking for IP# change"));
+	DO(http_init(client, "Checking for IP# change", strstr(provider->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4));
 
 	/* Prepare request for IP server */
 	memset(ctx->work_buf, 0, ctx->work_buflen);
@@ -615,7 +615,7 @@ static int send_update(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, int 
 		DO(info->system->setup(ctx, info, alias));
 
 	client->ssl_enabled = info->ssl_enabled;
-	rc = http_init(client, "Sending IP# update to DDNS server");
+	rc = http_init(client, "Sending IP# update to DDNS server", strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
 	if (rc) {
 		/* Update failed, force update again in ctx->cmd_check_period seconds */
 		alias->force_addr_update = 1;
@@ -657,9 +657,9 @@ static int send_update(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, int 
 
 	rc = info->system->response(&trans, info, alias);
 	if (rc) {
-		logit(LOG_WARNING, "%s error in DDNS server response:",
-		      rc == RC_DDNS_RSP_RETRY_LATER || rc == RC_DDNS_RSP_TOO_FREQUENT ? "Temporary" : "Fatal");
-		logit(LOG_WARNING, "[%d %s]", trans.status, trans.status_desc);
+		logit(LOG_WARNING, "%s error in DDNS server response: %s",
+		      rc == RC_DDNS_RSP_RETRY_LATER || rc == RC_DDNS_RSP_TOO_FREQUENT ? "Temporary" : "Fatal", error_str(rc));
+//		logit(LOG_WARNING, "[%d %s]", trans.status, trans.status_desc);
 		logit(LOG_DEBUG, "%s", trans.rsp_body != trans.rsp ? trans.rsp_body : "");
 
 		/* Update failed, force update again in ctx->cmd_check_period seconds */

--- a/src/gnutls.c
+++ b/src/gnutls.c
@@ -191,7 +191,7 @@ int ssl_fail(http_t *client, int rc)
 	return rc;
 }
 
-int ssl_open(http_t *client, char *msg)
+int ssl_open(http_t *client, char *msg, int force)
 {
 	const gnutls_datum_t *cert_list;
 	unsigned int cert_list_size = 0;
@@ -203,7 +203,7 @@ int ssl_open(http_t *client, char *msg)
 	int ret;
 
 	if (!client->ssl_enabled)
-		return tcp_init(&client->tcp, msg);
+		return tcp_init(&client->tcp, msg, force);
 
 	/* Try to figure out location of trusted CA certs on system */
 	if (ssl_set_ca_location())
@@ -239,7 +239,7 @@ int ssl_open(http_t *client, char *msg)
 	http_get_port(client, &port);
 	if (!port)
 		http_set_port(client, HTTPS_DEFAULT_PORT);
-	DO(tcp_init(&client->tcp, msg));
+	DO(tcp_init(&client->tcp, msg, force));
 
 	/* Forward TCP socket to GnuTLS, the set_int() API is perhaps too new still ... since 3.1.9 */
 //	gnutls_transport_set_int(client->ssl, client->tcp.socket);

--- a/src/http.c
+++ b/src/http.c
@@ -59,13 +59,13 @@ static int local_set_params(http_t *client)
 	return 0;
 }
 
-int http_init(http_t *client, char *msg)
+int http_init(http_t *client, char *msg, int force)
 {
 	int rc = 0;
 
 	do {
 		TRY(local_set_params(client));
-		TRY(ssl_open(client, msg));
+		TRY(ssl_open(client, msg, force));
 	}
 	while (0);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -9,18 +9,18 @@ int ssl_init(void) { return 0; }
 
 void ssl_exit(void) {}
 
-int ssl_open(http_t *client, char *msg)
+int ssl_open(http_t *client, char *msg, int force)
 {
 	int port = 0;
 	int rc;
 
 	if (!client->ssl_enabled)
-		return tcp_init(&client->tcp, msg);
+		return tcp_init(&client->tcp, msg, force);
 
 	http_get_port(client, &port);
 	if (!port)
 		http_set_port(client, HTTPS_DEFAULT_PORT);
-	rc = tcp_init(&client->tcp, msg);
+	rc = tcp_init(&client->tcp, msg, force);
 	if (rc)
 		return rc;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -146,7 +146,7 @@ static int ssl_fail(http_t *client, int rc)
 	return rc;
 }
 
-int ssl_open(http_t *client, char *msg)
+int ssl_open(http_t *client, char *msg, int force)
 {
 	const char *sn;
 	char buf[512];
@@ -155,12 +155,12 @@ int ssl_open(http_t *client, char *msg)
 	int rc;
 
 	if (!client->ssl_enabled)
-		return tcp_init(&client->tcp, msg);
+		return tcp_init(&client->tcp, msg, force);
 
 	http_get_port(client, &port);
 	if (!port)
 		http_set_port(client, HTTPS_DEFAULT_PORT);
-	DO(tcp_init(&client->tcp, msg));
+	DO(tcp_init(&client->tcp, msg, force));
 
 	logit(LOG_INFO, "%s, initiating HTTPS ...", msg);
 	client->ssl_ctx = SSL_CTX_new(SSLv23_client_method());
@@ -173,6 +173,7 @@ int ssl_open(http_t *client, char *msg)
 #else
 	SSL_CTX_set_options(client->ssl_ctx, SSL_OP_SINGLE_DH_USE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
 #endif
+	/* verify should be optional. routers might not have accurate time setting */
 	SSL_CTX_set_verify(client->ssl_ctx, SSL_VERIFY_PEER, verify_callback);
 	SSL_CTX_set_verify_depth(client->ssl_ctx, 150);
 


### PR DESCRIPTION
for ipv4 providers we should enforce ipv4 mode and for ipv6 the same as ipv6

background. some providers implement a rate limit. since we update ipv4 and ipv6 in 2 steps, this leads often to a delay
until the second address is updated. with 2 different ips we may prevent this issue.
in case the enforced mode isnt operational, we fall back to auto mode to allow a fallback to the other connection mode.
on any error on first attempt no log is shown, since we fallback anyway.
falling back is required anyway. as discovered some providers do not have AAAA records for the api servers (easydns for instance) but allow to update AAAA record on the ddns host

please comment what you think 

Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>