### PR TITLE
Format string fixes for new plugins

### DIFF
--- a/plugins/dnshome.c
+++ b/plugins/dnshome.c
@@ -80,6 +80,7 @@ static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 			alias->name,
 			alias->address,
 			info->server_name.name,
+			info->creds.encoded_password,
 			info->user_agent);
 	} else {
 		return snprintf(ctx->request_buf, ctx->request_buflen,
@@ -88,6 +89,7 @@ static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 			alias->name,
 			alias->address,
 			info->server_name.name,
+			info->creds.encoded_password,
 			info->user_agent);
 	}
 }

--- a/plugins/mydns.c
+++ b/plugins/mydns.c
@@ -30,12 +30,11 @@
 	"Host: %s\r\n"							\
 	"User-Agent: %s\r\n\r\n"
 
-#define MYDNS_UPDATE_IP6_REQUEST						\
+#define MYDNS_UPDATE_IP6_REQUEST					\
 	"GET %s?"							\
 	"MID=%s&"							\
 	"PWD=%s&"							\
 	"IPV6ADDR=%s "							\
-	"GET %s?"							\
 	"HTTP/1.0\r\n"							\
 	"Host: %s\r\n"							\
 	"User-Agent: %s\r\n\r\n"

--- a/plugins/twodns.c
+++ b/plugins/twodns.c
@@ -21,7 +21,7 @@
 
 #include "plugin.h"
 
-#define TWODNS_UPDATE_IP_REQUEST						\
+#define TWODNS_UPDATE_IP_REQUEST					\
 	"GET %s?"							\
 	"hostname=%s&"							\
 	"ip=%s "							\
@@ -56,6 +56,7 @@ static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 		alias->name,
 		alias->address,
 		info->server_name.name,
+		info->creds.encoded_password,
 		info->user_agent);
 }
 


### PR DESCRIPTION
This PR fixes format string errors in three recently added plugins.  The first commit I'm not too sure about since I don't know if the providers require basic auth or not.

Hopefully @BrainSlayer can have a look and confirm my fixes.