### PR TITLE
Mention that checkip-path supports query params

### DIFF
--- a/man/inadyn.conf.5
+++ b/man/inadyn.conf.5
@@ -196,8 +196,8 @@ and
 for the given DDNS provider.  For
 .Cm custom()
 DDNS setups it defaults to the built-in default (abvove).
-.It Cm checkip-path = "/some/checkip/url"
-Optional server path for check IP server, defaults to "/".  When the
+.It Cm checkip-path = "/some/checkip/url?param=value"
+Optional server path and query string for check IP server, defaults to "/".  When the
 .Cm checkip-server
 is set to
 .Cm default ,


### PR DESCRIPTION
While possibly not commonly used by checkip servers, query string parameters are supported in `inadyn` via `checkip-path`.