### PR TITLE
Fix #421: use Docker :latest tag only for latest In-a-Dyn release

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,12 +24,15 @@ jobs:
         id: vars
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [ "$VERSION" == "master" ] && VERSION=latest
-          echo "ver=${VERSION}" >> $GITHUB_OUTPUT
+          if [ "$VERSION" = "master" ]; then
+            echo "tags=troglobit/inadyn:build-${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
+          else
+            echo "tags=troglobit/inadyn:$VERSION,troglobit/inadyn:latest" >> $GITHUB_OUTPUT
+          fi
       - uses: docker/build-push-action@v4
         with:
           push: true
-          tags: troglobit/inadyn:${{ steps.vars.outputs.ver }}
+          tags: ${{ steps.vars.outputs.tags }}
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le
   ghcr:
     runs-on: ubuntu-latest
@@ -52,9 +55,14 @@ jobs:
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          if [ "$VERSION" = "master" ]; then
+            VERSION="build-${GITHUB_RUN_NUMBER}"
+          else
+            VERSION="$VERSION latest"
+          fi
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          for ver in $VERSION; do
+            docker tag $IMAGE_NAME $IMAGE_ID:$ver
+            docker push $IMAGE_ID:$ver
+          done


### PR DESCRIPTION
Ever since first adding support for building containers, PR #329, In-a-Dyn container images have applied the `:latest` tag wrong.

According to [best practices][1], the `:latest` tag should be applied to the latest release of a software, not the latest build.

This patch changes that, using [GitHub action variables][2] to set up a list of tags or generate a version for tagging.  The docker builders take multiple tags [separated with comma][3] (',') and for GHCR we simply use a for-loop.

[1]: https://stevelasker.blog/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/
[2]: https://docs.github.com/en/actions/learn-github-actions/variables
[3]: https://github.com/docker/build-push-action