### PR TITLE
Use docker buildx, since docker build is deprecated.

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push image


### PR DESCRIPTION
Since `docker build` is being deprecated [see here](https://docs.docker.com/engine/deprecated/#legacy-builder-fallback). Simply change the Github actions to `docker buildx build` since it now how docker image are now build.