### PR TITLE
Always update to get the latest list of available packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add --virtual .build-dependencies \
+RUN apk --update --no-cache add --virtual .build-dependencies \
   autoconf \
   automake \
   confuse-dev \
@@ -17,7 +17,7 @@ RUN ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=
 
 FROM alpine:latest
 
-RUN apk --no-cache add \
+RUN apk --update --no-cache add \
   ca-certificates \
   confuse \
   gnutls


### PR DESCRIPTION
This is just to have a peace of mind, we just always tell `Alpine APK` to always update the list of available packages before installing dependencies.