### PR TITLE
Fix support for namecheap

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ For the complete list, see `inadyn -L`, for machine friendly JSON
 output, use `inadyn -L -j`.
 
 DDNS providers not supported natively can be enabled using the custom,
-or generic, DDNS plugin.  E.g. <https://www.namecheap.com>.  See below
-for configuration examples.
+or generic, DDNS plugin. See below for configuration examples.
 
 In-A-Dyn defaults to HTTPS, but not all providers may support this, so
 try disabling SSL for the update (`ssl = false`) or the checkip phase
@@ -332,6 +331,7 @@ hostname syntax differs from above:
         ddns-server = dynamicdns.park-your-domain.com
         ddns-path   = "/update?domain=%u&password=%p&host=%h&ip=%i"
         hostname    = { "@", "www", "test" }
+        ddns-response = "<ErrCount>0</ErrCount>"
     }
 
 Here three hostnames are updated, one HTTP GET update request for every

--- a/plugins/namecheap.c
+++ b/plugins/namecheap.c
@@ -23,9 +23,9 @@
 
 #define NAMECHEAP_UPDATE_IP_REQUEST					\
 	"GET %s?"							\
-	"host=%s&"							\
-	"password=%s&"							\
 	"domain=%s&"							\
+	"password=%s&"							\
+	"host=%s&"							\
 	"ip=%s "							\
 	"HTTP/1.0\r\n"							\
 	"Host: %s\r\n"							\
@@ -72,7 +72,7 @@ static int response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias)
 
 	DO(http_status_valid(trans->status));
 
-	if (strstr(rsp, "good") || strstr(rsp, "nochg"))
+	if (strstr(rsp, "<ErrCount>0</ErrCount>"))
 		return 0;
 
 	return RC_DDNS_RSP_NOTOK;


### PR DESCRIPTION
This PR fixes the 2 problems with the current namecheap support and also updates the `README.md` to reflect that.

-----
The first problem stems from the `good` and `nochg` strings no longer getting sent back, making `inadyn` think the request failed (while it might not have).
The example in the `README.md` on the other hand will always succeed, since `true` is always in the response, even if it failed. Refer to the examples below.

I have decided to replace both with a check for `<ErrCount>0</ErrCount>`.

<details><summary>faulty response</summary>

```xml
<?xml version="1.0" encoding="utf-16"?>
<interface-response>
  <Command>SETDNSHOST</Command>
  <Language>eng</Language>
  <ErrCount>1</ErrCount>
  <errors>
    <Err1>Passwords do not match</Err1>
  </errors>
  <ResponseCount>1</ResponseCount>
  <responses>
    <response>
      <Description>Passwords do not match</Description>
      <ResponseNumber>304156</ResponseNumber>
      <ResponseString>Validation error; invalid ; password</ResponseString>
    </response>
  </responses>
  <Done>true</Done>
  <debug><![CDATA[]]></debug>
</interface-response>
```
</details>

<details><summary>successful response</summary>

```xml
<?xml version="1.0" encoding="utf-16"?>
<interface-response>
  <Command>SETDNSHOST</Command>
  <Language>eng</Language>
  <IP>XXX.XXX.XXX.XXX</IP>
  <ErrCount>0</ErrCount>
  <errors />
  <ResponseCount>0</ResponseCount>
  <responses />
  <Done>true</Done>
  <debug><![CDATA[]]></debug>
</interface-response>
```
</details>

-----
The second problem is `username` and `hostname` being swapped in `NAMECHEAP_UPDATE_IP_REQUEST` causing it to send `domain=%h`, `host=%u` instead of `domain=%u`, `host=%h`. While we can work around this by swapping `username` and `hostname` in the config, this means we cannot specify multiple hostnames.

I have swapped the two fields and think it is worth this breaking change for ease of use, especially since the plugin is currently broken and people couldn't be relying on it anyways.

<details><summary>current option (custom provider)</summary>

```py
custom namecheap {
  username    = domain.tld
  password    = mypass
  ddns-server = dynamicdns.park-your-domain.com
  ddns-path   = "/update?domain=%u&password=%p&host=%h&ip=%i"
  ddns-response = "<ErrCount>0</ErrCount>"
  hostname = { "@" "www" }
}
```
</details><details><summary>current option (plugin)</summary>

```py
provider default@namecheap.com:1 {
  username = "@"
  password = mypass
  hostname = domain.tld
}
provider default@namecheap.com:2 {
  username = "www"
  password = mypass
  hostname = domain.tld
}
```
</details><details><summary>new option</summary>

```py
provider default@namecheap.com {
  username = domain.tld
  password = mypass
  hostname = { "@" "www" }
}
```
</details>