### PR TITLE
Remove duplicate branches in request of plugins

### DIFF
--- a/plugins/dnshome.c
+++ b/plugins/dnshome.c
@@ -73,16 +73,6 @@ static ddns_system_t plugin_v6 = {
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 {
-	if (strstr(info->system->name, "ipv6"))
-		return snprintf(ctx->request_buf, ctx->request_buflen,
-			info->system->server_req,
-			info->server_url,
-			alias->name,
-			alias->address,
-			info->server_name.name,
-			info->creds.encoded_password,
-			info->user_agent);
-
 	return snprintf(ctx->request_buf, ctx->request_buflen,
 			info->system->server_req,
 			info->server_url,

--- a/plugins/ipv64.c
+++ b/plugins/ipv64.c
@@ -74,16 +74,6 @@ static ddns_system_t plugin_v6 = {
 
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 {
-	if (strstr(info->system->name, "ipv6"))
-		return snprintf(ctx->request_buf, ctx->request_buflen,
-			info->system->server_req,
-			info->server_url,
-			alias->name,
-			alias->address,
-			info->server_name.name,
-			info->creds.encoded_password,
-			info->user_agent);
-
 	return snprintf(ctx->request_buf, ctx->request_buflen,
 			info->system->server_req,
 			info->server_url,


### PR DESCRIPTION
The check for whether the name contains "ipv6" is not necessary for the plugins "dnshome" and "ipv64", as the code path for both branches is the same.
Furthermore the check is rather confusing in the context of the provider named "ipv64.net", as "ipv6" is also contained in the provider name itself.