### PR TITLE
Fix issue with detection whether to use ipv6 or ipv4

### DIFF
--- a/include/ddns.h
+++ b/include/ddns.h
@@ -222,6 +222,7 @@ extern uid_t uid;
 extern gid_t gid;
 
 int ddns_main_loop (ddns_t *ctx);
+int ddns_get_tcp_force(const ddns_info_t *info);
 
 int common_request (ddns_t       *ctx,   ddns_info_t *info, ddns_alias_t *alias);
 int common_response(http_trans_t *trans, ddns_info_t *info, ddns_alias_t *alias);

--- a/plugins/cloudflare.c
+++ b/plugins/cloudflare.c
@@ -249,7 +249,7 @@ static int json_extract(char *dest, size_t dest_size, const ddns_info_t *info, c
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	CHECK(http_init(&client, "Json query",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4));
+	CHECK(http_init(&client, "Json query", ddns_get_tcp_force(info)));
 
 	trans.req = request;
 	trans.req_len = request_len;

--- a/plugins/core-networks.c
+++ b/plugins/core-networks.c
@@ -52,7 +52,7 @@ static ddns_system_t plugin = {
 static int request(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 {
 	char *keepip;
-	if (strstr(info->system->name, "ipv6"))
+	if (ddns_get_tcp_force(info) == TCP_FORCE_IPV6)
 		keepip = "keepipv4=1";
 	else
 		keepip = "keepipv6=1";

--- a/plugins/dnspod.c
+++ b/plugins/dnspod.c
@@ -100,7 +100,7 @@ static int fetch_record_id(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, 
 	http_set_remote_name(&client, info->server_name.name);
 	client.ssl_enabled = info->ssl_enabled;
 
-	rc = http_init(&client, "Sending record list query",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
+	rc = http_init(&client, "Sending record list query", ddns_get_tcp_force(info));
 	if (rc)
 		return -rc;
 
@@ -169,7 +169,7 @@ static int setup(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias)
 	int len;
 	char *record_type;
 	
-	if (strstr(info->system->name, "ipv6"))
+	if (ddns_get_tcp_force(info) == TCP_FORCE_IPV6)
 		record_type="AAAA";
 	else
 		record_type="A";

--- a/plugins/freedns.c
+++ b/plugins/freedns.c
@@ -69,7 +69,7 @@ static char *fetch_keys(ddns_t *ctx, ddns_info_t *info)
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	rc = http_init(&client, "Fetching account API key",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
+	rc = http_init(&client, "Fetching account API key", ddns_get_tcp_force(info));
 	if (rc)
 		return NULL;
 

--- a/plugins/porkbun.c
+++ b/plugins/porkbun.c
@@ -225,7 +225,7 @@ static int json_extract(char *dest, size_t dest_size, const ddns_info_t *info, c
 	http_set_remote_name(&client, info->server_name.name);
 
 	client.ssl_enabled = info->ssl_enabled;
-	CHECK(http_init(&client, "Json query",strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4));
+	CHECK(http_init(&client, "Json query", ddns_get_tcp_force(info)));
 
 	trans.req = request;
 	trans.req_len = request_len;

--- a/src/cache.c
+++ b/src/cache.c
@@ -184,7 +184,7 @@ int write_cache_file(ddns_alias_t *alias, const char *name)
 	cache_file(alias->name, name, path, sizeof(path));
 	fp = fopen(path, "w");
 	if (fp) {
-		if (strstr(name, "v6"))
+		if (strstr(name, "ipv6") == name)
 			logit(LOG_NOTICE, "Updating IPv6 cache for %s", alias->name);
 		else
 			logit(LOG_NOTICE, "Updating IPv4 cache for %s", alias->name);

--- a/src/cache.c
+++ b/src/cache.c
@@ -184,7 +184,8 @@ int write_cache_file(ddns_alias_t *alias, const char *name)
 	cache_file(alias->name, name, path, sizeof(path));
 	fp = fopen(path, "w");
 	if (fp) {
-		if (strstr(name, "ipv6") == name)
+		const char *ipv6_prefix = "ipv6";
+		if (strncmp(name, ipv6_prefix, strlen(ipv6_prefix)) == 0)
 			logit(LOG_NOTICE, "Updating IPv6 cache for %s", alias->name);
 		else
 			logit(LOG_NOTICE, "Updating IPv4 cache for %s", alias->name);

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -1066,7 +1066,8 @@ int ddns_main_loop(ddns_t *ctx)
 
 int ddns_get_tcp_force(const ddns_info_t *info) {
 	const char* name = info->system->name;
-	if (strstr(name, "ipv6") == name) {
+	const char *ipv6_prefix = "ipv6";
+	if (strncmp(name, ipv6_prefix, strlen(ipv6_prefix)) == 0) {
 		return TCP_FORCE_IPV6;
 	}
 	return TCP_FORCE_IPV4;

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -136,7 +136,7 @@ static int server_transaction(ddns_t *ctx, ddns_info_t *provider)
 
 	client = &provider->checkip;
 	client->ssl_enabled = provider->checkip_ssl;
-	DO(http_init(client, "Checking for IP# change", strstr(provider->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4));
+	DO(http_init(client, "Checking for IP# change", ddns_get_tcp_force(provider)));
 
 	/* Prepare request for IP server */
 	memset(ctx->work_buf, 0, ctx->work_buflen);
@@ -618,7 +618,7 @@ static int send_update(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, int 
 		DO(info->system->setup(ctx, info, alias));
 
 	client->ssl_enabled = info->ssl_enabled;
-	rc = http_init(client, "Sending IP# update to DDNS server", strstr(info->system->name, "ipv6") ? TCP_FORCE_IPV6 : TCP_FORCE_IPV4);
+	rc = http_init(client, "Sending IP# update to DDNS server", ddns_get_tcp_force(info));
 	if (rc) {
 		/* Update failed, force update again in ctx->cmd_check_period seconds */
 		alias->force_addr_update = 1;
@@ -1062,6 +1062,14 @@ int ddns_main_loop(ddns_t *ctx)
 	cached_num_iterations = ctx->num_iterations;
 
 	return rc;
+}
+
+int ddns_get_tcp_force(const ddns_info_t *info) {
+	const char* name = info->system->name;
+	if (strstr(name, "ipv6") == name) {
+		return TCP_FORCE_IPV6;
+	}
+	return TCP_FORCE_IPV4;
 }
 
 /**


### PR DESCRIPTION
The issue was occurring while checking whether the provider name contained
"ipv6" as an indication for whether to use IPv4 or IPv4. The check
confused a definition like "ipv4@ipv64.net" to use IPv6 due to having
"ipv6" in the name.

To address the issue we changed the check to whether the prefix of
the provider name is "ipv6".

While doing so, we factored out this check into a own function taking
a ddns_info_t * struct as an argument.
