### PR TITLE
Add information on installing via MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,14 @@ To run the latest version from the master branch, install the git tap instead:
 
 Either of these will install all dependencies.
 
+### MacPorts (macOS)
+
+You can also install In-A-Dyn on macOS using [MacPorts](https://www.macports.org):
+
+    sudo port install inadyn
+
+You can find more information at In-A-Dyn's [ports page](https://ports.macports.org/port/inadyn/).
+
 ### Building from Source
 
 First download the latest official In-A-Dyn release from GitHub:


### PR DESCRIPTION
`inadyn` has now been added to [MacPorts](https://www.macports.org).

This PR adds information to the README on installing it via that method.

https://ports.macports.org/port/inadyn/