### PR TITLE
Avoid creating cache directory for usage or check-config

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,7 @@ static void parse_privs(char *user)
 	}
 }
 
-static int compose_paths(void)
+static int compose_paths(int dryrun)
 {
 	/* Default .conf file path: "/etc" + '/' + "inadyn" + ".conf" */
 	if (!config) {
@@ -242,7 +242,7 @@ static int compose_paths(void)
 			}
 
 			snprintf(cache_dir, len, "%s/.cache/%s", home, ident);
-			if (mkdir(cache_dir, 0755) && EEXIST != errno) {
+			if (!dryrun && mkdir(cache_dir, 0755) && EEXIST != errno) {
 				snprintf(cache_dir, len, "%s/.%s", home, ident);
 				mkdir(cache_dir, 0755);
 			}
@@ -256,7 +256,7 @@ static int usage(int code)
 {
         char pidfn[80];
 
-	DO(compose_paths());
+	DO(compose_paths(1));
 	if (pidfile_name[0] != '/')
 		snprintf(pidfn, sizeof(pidfn), "%s/%s.pid", RUNSTATEDIR, pidfile_name);
 	else
@@ -333,9 +333,7 @@ int main(int argc, char *argv[])
 {
 	int c, restart, rc = 0;
 	int use_syslog = 1;
-#ifndef DROP_CHECK_CONFIG
 	int check_config = 0;
-#endif
 	int list = 0, json = 0;
 	int background = 1;
 	static const struct option opt[] = {
@@ -484,7 +482,7 @@ int main(int argc, char *argv[])
 		return plugin_list(json);
 
 	/* Figure out .conf file, cache directory, and PID file name */
-	DO(compose_paths());
+	DO(compose_paths(check_config));
 
 #ifndef DROP_CHECK_CONFIG
 	if (check_config) {


### PR DESCRIPTION
It's unexpected that inadyn --help would try to create a directory, or that a --cache-dir argument would be required when using --check-config before running the service with --cache-dir

This might incorrectly print a default of ~/.cache/inadyn in --help if /var/cache/inadyn is missing, and then fail to create the directory and fallback to ~/.inadyn when actually running it, but this is a problem that already exists when running inadyn first with no ~/.cache dir and creating ~/.cache later: after a reset the directory would change with no apparent reason.
A further improvement might check if ~/.inadyn exists but not ~/.cache/inadyn and use that.