### PR TITLE
Remove log when /var/cache/inadyn is missing and no $HOME

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -227,8 +227,14 @@ static int compose_paths(int dryrun)
 
 			home = getenv("HOME");
 			if (!home) {
-				logit(LOG_ERR, "Cannot create fallback cache dir: %s", strerror(errno));
-				return 0;
+				/* ignore this for --check-config: the service won't start if the
+				 * main process is not given the option */
+				if (dryrun)
+					return 0;
+				logit(LOG_ERR, "%s: not writable, $HOME missing, please use --cache-dir=PATH",
+				      cache_dir);
+				free(cache_dir);
+				return 1;
 			}
 
 			/* Fallback cache dir: $HOME + "/.cache/" + "inadyn" */


### PR DESCRIPTION
If the service uses the default /var/cache/inadyn directory, then that
directory will have been created and there is no problem, but if using
an alternate directory with --cache-dir is used then it must also be
passed to any --check-config invocation as well lest this error message
is printed:
```
Cannot create fallback cache dir: No such file or directory
```

However, there already is another message that is only printed on
service start and not on check-conf:
```
inadyn[1902671]: No write permission to /var/cache/inadyn: Permission denied
inadyn[1902671]: Cannot guarantee DDNS server won't lock you out for excessive updates.
```

So just remove the 'Cannot create fallback' message.

------------------

This is a follow-up on #522 -- sorry for bugging you on a closed PR there!
You've suggested adding an extra fallback to /tmp, and I first did that, but when writing the commit message at this point I think we're better off without the extra fallback:
- I think there's already too many fallbacks; it's a matter of like but I prefer things to fail hard than to try too hard in non-optimal situation
- the cache dir is meant to avoid spamming upstream services on restart but /tmp will likely be gone after reboot, so it'd just give a false impression of working (although it'll still work for service restarts, so I guess it's better than nothing?)
- since the cache dir being missing isn't a fatal error, I think it's better to have inadyn print many warnings everytime the cache dir is used than fallback and mask the error behind a single warning.. Although at this point I guess it's up to the user to fix their setup anyway.

If you think a fallback is better I have a commit here[1] that just needs message fixing a bit, so just tell me and I'll swap it in this PR.
[1] https://github.com/martinetd/inadyn/commit/06d61f1afe903ca1ac4927e9ca9c0bde6ab2f785

Thanks,