### PR TITLE
fix dnspod error: Communication with checkip server %s failed

### DIFF
--- a/plugins/dnspod.c
+++ b/plugins/dnspod.c
@@ -46,7 +46,7 @@ static ddns_system_t plugin = {
 	.checkip_ssl  = DYNDNS_MY_IP_SSL,
 
 	.server_name  = "dnsapi.cn",
-	.server_url   = ""
+	.server_url   = "/"
 };
 
 static ddns_system_t plugin_v6 = {
@@ -61,7 +61,7 @@ static ddns_system_t plugin_v6 = {
 	.checkip_ssl  = DDNS_CHECKIP_SSL_SUPPORTED,
 
 	.server_name  = "dnsapi.cn",
-	.server_url   = ""
+	.server_url   = "/"
 };
 
 static int fetch_record_id(ddns_t *ctx, ddns_info_t *info, ddns_alias_t *alias, char *domain, char *prefix)

--- a/src/ddns.c
+++ b/src/ddns.c
@@ -334,7 +334,7 @@ static int parse_my_address(char *buffer, char *address, size_t len)
 
 static int get_address_remote(ddns_t *ctx, ddns_info_t *info, char *address, size_t len)
 {
-	if (!info->server_url[0])
+	if (!info->checkip_name.name[0])
 		return 1;
 
 	DO(server_transaction(ctx, info));


### PR DESCRIPTION
The plugin of dnspod had server_url = "". When I configured check_ip_server, the "get address from remote" function in ddns.c gets always returned.
`static int get_address_remote(ddns_t *ctx, ddns_info_t *info, char *address, size_t len)
{
	if (!info->server_url[0])
		return 1;`

The easy fix is change empty string to "/" in dnspod plugin.
Well, I believe another fix to the IF-condition "if (!info->server_url[0])" should be done. Maybe some plugin has empty server_url but always has server_name.
`static ddns_system_t plugin = {
        .server_name  = "dnsapi.cn",
        .server_url   = ""
};
`
Like as
```
- if (!info->server_url[0])
+ if (!info->server_name[0])
```